### PR TITLE
feat: add lcity agent skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,19 @@ curl.exe -X PATCH http://localhost:3001/board/posts ^
 
 Read-only endpoints continue to work without headers.
 
+## Letta Code skill
+
+This repo includes a Letta Code skill at `skills/living-in-letta-city/` for controlling NPCs through the existing `lcity` CLI. Use it when an agent should act inside the city instead of calling the World API by hand.
+
+Example:
+
+```powershell
+$env:SIM_API_KEY="dev_key_change_me"
+$env:LCITY_API_BASE="http://localhost:3001"
+node .\skills\living-in-letta-city\scripts\lcity-agent.mjs --agent-id eddy_lin health_check
+node .\skills\living-in-letta-city\scripts\lcity-agent.mjs --agent-id eddy_lin move_to --location-id hobbs_cafe_seating
+```
+
 ## Documentation
 - Contribution workflow: `CONTRIBUTING.md`
 - Canonical product brief: `docs/letta-city-sim-prd.md`

--- a/README.md
+++ b/README.md
@@ -140,6 +140,8 @@ node .\skills\living-in-letta-city\scripts\lcity-agent.mjs --agent-id eddy_lin h
 node .\skills\living-in-letta-city\scripts\lcity-agent.mjs --agent-id eddy_lin move_to --location-id hobbs_cafe_seating
 ```
 
+When running inside Letta Code, the wrapper can use the runtime `AGENT_ID` env var automatically. Set `LCITY_AGENT_ID` to override the city identity when the sim id differs from the Letta agent id.
+
 ## Documentation
 - Contribution workflow: `CONTRIBUTING.md`
 - Canonical product brief: `docs/letta-city-sim-prd.md`

--- a/skills/living-in-letta-city/SKILL.md
+++ b/skills/living-in-letta-city/SKILL.md
@@ -14,6 +14,12 @@ Required:
 - `LCITY_API_BASE`, or pass `--api-base`.
 - An agent identity for commands that require acting as an NPC.
 
+Identity resolution order:
+1. `--agent-id`.
+2. `LCITY_AGENT_ID`.
+3. `AGENT_ID` from the Letta Code runtime.
+4. `--agent-id-file`.
+
 Common local bases:
 - Bundled demo through frontend proxy: `http://localhost:3002/api`.
 - Raw World API: `http://localhost:3001`.
@@ -24,7 +30,7 @@ Preferred wrapper:
 node <skill>/scripts/lcity-agent.mjs --repo ~/letta/letta-city-sim --api-base http://localhost:3002/api --sim-key dev_key_change_me --agent-id eddy_lin health_check
 ```
 
-If already inside the repo, `--repo` can be omitted.
+If already inside the repo, `--repo` can be omitted. If `LCITY_AGENT_ID` or `AGENT_ID` is set, `--agent-id` can be omitted for commands that act as the current agent.
 
 ## Core commands
 
@@ -32,6 +38,7 @@ Check identity/state:
 
 ```bash
 node <skill>/scripts/lcity-agent.mjs --agent-id eddy_lin health_check
+node <skill>/scripts/lcity-agent.mjs health_check
 ```
 
 Look around:

--- a/skills/living-in-letta-city/SKILL.md
+++ b/skills/living-in-letta-city/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: living-in-letta-city
+description: Operates NPCs in letta-city-sim through the lcity CLI. Use when acting as a city resident, playtesting letta-city-sim, controlling agents/NPCs, moving around Smallville, posting to the board, inspecting locations, pathfinding, using inventory, sleeping/waking, or driving the World API via lcity.
+---
+
+# Living in Letta City
+
+Use the existing `lcity` CLI as the action surface. Do not reimplement World API calls unless `lcity` lacks the command.
+
+## Setup
+
+Required:
+- `SIM_API_KEY`, or pass `--sim-key`.
+- `LCITY_API_BASE`, or pass `--api-base`.
+- An agent identity for commands that require acting as an NPC.
+
+Common local bases:
+- Bundled demo through frontend proxy: `http://localhost:3002/api`.
+- Raw World API: `http://localhost:3001`.
+
+Preferred wrapper:
+
+```bash
+node <skill>/scripts/lcity-agent.mjs --repo ~/letta/letta-city-sim --api-base http://localhost:3002/api --sim-key dev_key_change_me --agent-id eddy_lin health_check
+```
+
+If already inside the repo, `--repo` can be omitted.
+
+## Core commands
+
+Check identity/state:
+
+```bash
+node <skill>/scripts/lcity-agent.mjs --agent-id eddy_lin health_check
+```
+
+Look around:
+
+```bash
+node <skill>/scripts/lcity-agent.mjs list_locations
+node <skill>/scripts/lcity-agent.mjs get_location --id lin_kitchen
+node <skill>/scripts/lcity-agent.mjs nearby_locations --id lin_kitchen
+node <skill>/scripts/lcity-agent.mjs world_time
+```
+
+Move:
+
+```bash
+node <skill>/scripts/lcity-agent.mjs --agent-id eddy_lin move_to --location-id hobbs_cafe_seating
+node <skill>/scripts/lcity-agent.mjs --agent-id eddy_lin move_to_agent --target-agent-id sam_moore
+node <skill>/scripts/lcity-agent.mjs pathfind --from lin_bedroom --to hobbs_cafe_seating
+```
+
+Interact:
+
+```bash
+node <skill>/scripts/lcity-agent.mjs --agent-id maria_lopez board_post --text "Sketching in Ville Park today."
+node <skill>/scripts/lcity-agent.mjs board_posts
+node <skill>/scripts/lcity-agent.mjs --agent-id eddy_lin list_inventory
+node <skill>/scripts/lcity-agent.mjs --agent-id eddy_lin use_item --item-id apple_001 --quantity 1
+node <skill>/scripts/lcity-agent.mjs --agent-id eddy_lin sleep
+node <skill>/scripts/lcity-agent.mjs --agent-id eddy_lin wake_up
+```
+
+## Agent behavior loop
+
+When acting as an NPC:
+1. Run `health_check` to learn current location/state.
+2. Run `world_time`, `nearby_locations`, and optionally `board_posts`.
+3. Pick one small intention consistent with persona and current state.
+4. Use `pathfind` before long moves.
+5. Move or interact through `lcity`.
+6. Post to the board only when the message would be public and useful.
+7. Avoid spamming actions. One meaningful action per turn is usually enough.
+
+## Guardrails
+
+- Keep agent identity stable. Do not switch `--agent-id` unless explicitly asked.
+- Prefer nearby moves over arbitrary teleport-like jumps.
+- Read before writing: inspect location, inventory, board, or path before mutating.
+- Use public board posts sparingly.
+- If a command fails, report the JSON error and inspect nearby state before retrying.

--- a/skills/living-in-letta-city/scripts/lcity-agent.mjs
+++ b/skills/living-in-letta-city/scripts/lcity-agent.mjs
@@ -31,7 +31,7 @@ const tokens = process.argv.slice(2);
 let repo = defaultRepo();
 let apiBase = process.env.LCITY_API_BASE || "http://localhost:3001";
 let simKey = process.env.SIM_API_KEY || "";
-let agentId = "";
+let agentId = process.env.LCITY_AGENT_ID || process.env.AGENT_ID || "";
 let agentIdFile = "";
 const rest = [];
 

--- a/skills/living-in-letta-city/scripts/lcity-agent.mjs
+++ b/skills/living-in-letta-city/scripts/lcity-agent.mjs
@@ -1,0 +1,80 @@
+#!/usr/bin/env node
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, writeFileSync, existsSync } from "node:fs";
+import { tmpdir, homedir } from "node:os";
+import path from "node:path";
+
+function usage() {
+  console.error(`Usage:
+  lcity-agent.mjs [--repo <path>] [--api-base <url>] [--sim-key <key>] [--agent-id <id>|--agent-id-file <path>] <lcity-command> [args...]
+
+Examples:
+  lcity-agent.mjs --agent-id eddy_lin health_check
+  lcity-agent.mjs --agent-id eddy_lin move_to --location-id lin_kitchen
+  lcity-agent.mjs pathfind --from lin_bedroom --to hobbs_cafe_seating`);
+}
+
+function expandHome(value) {
+  if (!value) return value;
+  if (value === "~") return homedir();
+  if (value.startsWith("~/")) return path.join(homedir(), value.slice(2));
+  return value;
+}
+
+function defaultRepo() {
+  if (process.env.LCITY_REPO) return expandHome(process.env.LCITY_REPO);
+  if (existsSync(path.join(process.cwd(), "lcity", "bin", "lcity.mjs"))) return process.cwd();
+  return path.join(homedir(), "letta", "letta-city-sim");
+}
+
+const tokens = process.argv.slice(2);
+let repo = defaultRepo();
+let apiBase = process.env.LCITY_API_BASE || "http://localhost:3001";
+let simKey = process.env.SIM_API_KEY || "";
+let agentId = "";
+let agentIdFile = "";
+const rest = [];
+
+for (let i = 0; i < tokens.length; i += 1) {
+  const token = tokens[i];
+  if (token === "--repo") repo = expandHome(tokens[++i]);
+  else if (token === "--api-base") apiBase = tokens[++i];
+  else if (token === "--sim-key") simKey = tokens[++i];
+  else if (token === "--agent-id") agentId = tokens[++i];
+  else if (token === "--agent-id-file") agentIdFile = expandHome(tokens[++i]);
+  else rest.push(token);
+}
+
+if (rest.length === 0) {
+  usage();
+  process.exit(2);
+}
+
+const lcityPath = path.join(repo, "lcity", "bin", "lcity.mjs");
+if (!existsSync(lcityPath)) {
+  console.error(JSON.stringify({ ok: false, error: `lcity not found at ${lcityPath}` }));
+  process.exit(1);
+}
+
+if (agentId && !agentIdFile) {
+  const dir = mkdtempSync(path.join(tmpdir(), "lcity-agent-"));
+  agentIdFile = path.join(dir, "agent_id");
+  writeFileSync(agentIdFile, `${agentId}\n`, "utf8");
+}
+
+const args = [lcityPath, "--api-base", apiBase];
+if (simKey) args.push("--sim-key", simKey);
+if (agentIdFile) args.push("--agent-id-file", agentIdFile);
+args.push(...rest);
+
+const result = spawnSync(process.execPath, args, {
+  cwd: repo,
+  stdio: "inherit",
+  env: {
+    ...process.env,
+    LCITY_API_BASE: apiBase,
+    SIM_API_KEY: simKey || process.env.SIM_API_KEY || "",
+  },
+});
+
+process.exit(result.status ?? 1);


### PR DESCRIPTION
## Summary
- Add a repo-local Letta Code skill at `skills/living-in-letta-city/` for NPC control through the existing `lcity` CLI.
- Include a small `lcity-agent.mjs` wrapper that resolves identity from `--agent-id`, `LCITY_AGENT_ID`, or the Letta Code runtime `AGENT_ID`, then creates the temporary agent identity file expected by `lcity`.
- Forward commands with `SIM_API_KEY` / `LCITY_API_BASE` and document the skill entrypoint in the README.

Refs #38.

Checked locally against the bundled app with `health_check`, `world_time`, `list_locations`, `pathfind`, `move_to`, `board_post`, and `board_posts`. Also checked identity inference through both `LCITY_AGENT_ID` and `AGENT_ID`.

"Give the citizens a tool belt."

Written by Cameron ◯ Letta Code