### PR TITLE
fix: interpolate agent map markers

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Implemented so far:
 - Pathfinding API (`GET /pathfind` using Dijkstra)
 - Inventory API (list/add/remove/adjacent-only transfer)
 - Notice board API (public text-only + internal audit events)
-- Objects API (`GET /objects/:location_id`, `PATCH /objects/:id`)
+- Objects API (`GET /locations/:location_id/objects`, `PATCH /objects/:id`)
 - Events API (`GET /events`, `POST /events`)
 - World time API (`GET /world/time`)
 - Canonical QA checklist in `TESTING.md`

--- a/TESTING.md
+++ b/TESTING.md
@@ -178,7 +178,7 @@ curl.exe -X PATCH http://localhost:3001/board/posts ^
   -H "x-sim-api-key: $env:SIM_API_KEY" ^
   -d "{\"text\":\"Town hall at 6 PM\"}"
 
-curl.exe http://localhost:3001/objects/lin_kitchen
+curl.exe http://localhost:3001/locations/lin_kitchen/objects
 
 curl.exe -X PATCH http://localhost:3001/objects/stove_lin_kitchen ^
   -H "Content-Type: application/json" ^
@@ -224,7 +224,7 @@ Validate room-level sleep behavior using a seeded bed object.
 After seeding, confirm the bedroom has a sleep-capable bed object:
 
 ```powershell
-curl.exe http://localhost:3001/objects/lin_bedroom
+curl.exe http://localhost:3001/locations/lin_bedroom/objects
 ```
 
 Expect a bed object such as `bed_lin_bedroom` with `occupied_by: null` and `sleep` in `actions`.

--- a/TESTING.md
+++ b/TESTING.md
@@ -68,16 +68,16 @@ curl.exe http://localhost:3001/agents/eddy_lin
 curl.exe -X PATCH http://localhost:3001/agents/move ^
   -H "Content-Type: application/json" ^
   -H "x-agent-id: eddy_lin" ^
-  -H "x-sim-api-key: $env:SIM_API_KEY" ^
+  -H "x-sim-key: $env:SIM_API_KEY" ^
   -d "{\"location_id\":\"lin_kitchen\"}"
 
 curl.exe -X PATCH http://localhost:3001/agents/eddy_lin/activity ^
   -H "Content-Type: application/json" ^
-  -H "x-sim-api-key: $env:SIM_API_KEY" ^
+  -H "x-sim-key: $env:SIM_API_KEY" ^
   -d "{\"activity\":\"Cooking lunch\"}"
 
 curl.exe -X DELETE http://localhost:3001/agents/eddy_lin/activity ^
-  -H "x-sim-api-key: $env:SIM_API_KEY"
+  -H "x-sim-key: $env:SIM_API_KEY"
 ```
 
 Expect:
@@ -93,17 +93,17 @@ curl.exe http://localhost:3001/inventory/eddy_lin
 
 curl.exe -X PATCH http://localhost:3001/inventory/eddy_lin/add ^
   -H "Content-Type: application/json" ^
-  -H "x-sim-api-key: $env:SIM_API_KEY" ^
+  -H "x-sim-key: $env:SIM_API_KEY" ^
   -d "{\"item_id\":\"sheet_music_001\"}"
 
 curl.exe -X PATCH http://localhost:3001/inventory/eddy_lin/remove ^
   -H "Content-Type: application/json" ^
-  -H "x-sim-api-key: $env:SIM_API_KEY" ^
+  -H "x-sim-key: $env:SIM_API_KEY" ^
   -d "{\"item_id\":\"sheet_music_001\"}"
 
 curl.exe -X PATCH http://localhost:3001/agents/eddy_lin/inventory/transfer ^
   -H "Content-Type: application/json" ^
-  -H "x-sim-api-key: $env:SIM_API_KEY" ^
+  -H "x-sim-key: $env:SIM_API_KEY" ^
   -d "{\"to_agent_id\":\"abigail_chen\",\"item_id\":\"sheet_music_001\"}"
 ```
 
@@ -130,7 +130,7 @@ Ensure an inventory row has:
 curl.exe -X POST http://localhost:3001/agents/use-item ^
   -H "Content-Type: application/json" ^
   -H "x-agent-id: eddy_lin" ^
-  -H "x-sim-api-key: $env:SIM_API_KEY" ^
+  -H "x-sim-key: $env:SIM_API_KEY" ^
   -d "{\"item_id\":\"apple_001\",\"quantity\":1}"
 ```
 
@@ -155,7 +155,7 @@ Expect:
 curl.exe -X PATCH http://localhost:3001/agents/eddy_lin/economy ^
   -H "Content-Type: application/json" ^
   -H "x-agent-id: eddy_lin" ^
-  -H "x-sim-api-key: $env:SIM_API_KEY" ^
+  -H "x-sim-key: $env:SIM_API_KEY" ^
   -d "{\"amount_cents\":250,\"reason\":\"Quest reward\"}"
 ```
 
@@ -175,7 +175,7 @@ curl.exe http://localhost:3001/board/posts
 curl.exe -X PATCH http://localhost:3001/board/posts ^
   -H "Content-Type: application/json" ^
   -H "x-agent-id: maria_lopez" ^
-  -H "x-sim-api-key: $env:SIM_API_KEY" ^
+  -H "x-sim-key: $env:SIM_API_KEY" ^
   -d "{\"text\":\"Town hall at 6 PM\"}"
 
 curl.exe http://localhost:3001/locations/lin_kitchen/objects
@@ -183,7 +183,7 @@ curl.exe http://localhost:3001/locations/lin_kitchen/objects
 curl.exe -X PATCH http://localhost:3001/objects/stove_lin_kitchen ^
   -H "Content-Type: application/json" ^
   -H "x-agent-id: eddy_lin" ^
-  -H "x-sim-api-key: $env:SIM_API_KEY" ^
+  -H "x-sim-key: $env:SIM_API_KEY" ^
   -d "{\"state\":{\"on\":true}}"
 
 curl.exe "http://localhost:3001/events?limit=20"

--- a/docs/letta-city-sim-prd.md
+++ b/docs/letta-city-sim-prd.md
@@ -113,7 +113,7 @@ INVENTORY
   POST   /inventory/transfer              atomic transfer between two agents or agent ↔ location
 
 WORLD OBJECTS
-  GET    /objects/:locationId             objects present at a location
+  GET    /locations/:locationId/objects   objects present at a location
   PATCH  /objects/:id                     update object state (e.g. stove → { "on": true })
 
 CONVERSATIONS
@@ -509,4 +509,3 @@ volumes:
 - **Public observatory** — read-only hosted demo anyone can watch live
 - **Agent creator UI** — drag-and-drop persona builder to add new citizens
 - **Scenario injector** — predefined drama events ("the cafe runs out of coffee", "it starts raining", "there's a noise complaint about Eddy's piano")
-

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -287,6 +287,8 @@ pre {
   color: #cbd5e1;
   font-size: 0.84rem;
   overflow: auto;
+  overflow-wrap: anywhere;
+  white-space: pre-wrap;
 }
 
 .loading,

--- a/frontend/components/PhaserMap.tsx
+++ b/frontend/components/PhaserMap.tsx
@@ -12,6 +12,9 @@ export function PhaserMap({ agents, locations }: Props) {
   const mountRef = useRef<HTMLDivElement | null>(null);
   const gameRef = useRef<unknown>(null);
   const sceneRef = useRef<{ applySnapshot: (snapshot: { agents: Agent[]; locations: Location[] }) => void } | null>(null);
+  const snapshotRef = useRef({ agents, locations });
+
+  snapshotRef.current = { agents, locations };
 
   useEffect(() => {
     let cancelled = false;
@@ -51,7 +54,7 @@ export function PhaserMap({ agents, locations }: Props) {
       });
 
       gameRef.current = game;
-      scene.applySnapshot({ agents, locations });
+      scene.applySnapshot(snapshotRef.current);
     }
 
     mountGame();
@@ -68,7 +71,7 @@ export function PhaserMap({ agents, locations }: Props) {
   }, []);
 
   useEffect(() => {
-    sceneRef.current?.applySnapshot({ agents, locations });
+    sceneRef.current?.applySnapshot(snapshotRef.current);
   }, [agents, locations]);
 
   return <div ref={mountRef} />;

--- a/frontend/game/TownScene.ts
+++ b/frontend/game/TownScene.ts
@@ -6,10 +6,17 @@ type TownSceneSnapshot = {
   locations: Location[];
 };
 
+type LocationAnchor = {
+  location: Location;
+  x: number;
+  y: number;
+};
+
 const PADDING_X = 140;
 const PADDING_Y = 110;
 const GRID_SIZE = 96;
 const TILE_SIZE = 76;
+const MARKER_TWEEN_MS = 700;
 
 function colorForAgent(agentId: string) {
   const palette = [0x2563eb, 0xdc2626, 0x16a34a, 0x9333ea, 0xea580c, 0x0891b2];
@@ -32,6 +39,9 @@ function getInitials(name: string) {
 export class TownScene extends Phaser.Scene {
   private snapshot: TownSceneSnapshot = { agents: [], locations: [] };
   private worldLayer!: Phaser.GameObjects.Container;
+  private staticLayer!: Phaser.GameObjects.Container;
+  private markerLayer!: Phaser.GameObjects.Container;
+  private agentMarkers = new Map<string, Phaser.GameObjects.Container>();
 
   constructor() {
     super("TownScene");
@@ -40,6 +50,11 @@ export class TownScene extends Phaser.Scene {
   create() {
     this.cameras.main.setBackgroundColor("#9fd3ff");
     this.worldLayer = this.add.container(0, 0);
+    this.staticLayer = this.add.container(0, 0);
+    this.markerLayer = this.add.container(0, 0);
+    // Keep markers on their own layer so websocket redraws can animate them
+    // without destroying the active tween every time the static map repaints.
+    this.worldLayer.add([this.staticLayer, this.markerLayer]);
     this.scale.on("resize", this.renderSnapshot, this);
     this.events.once(Phaser.Scenes.Events.SHUTDOWN, () => {
       this.scale.off("resize", this.renderSnapshot, this);
@@ -55,11 +70,12 @@ export class TownScene extends Phaser.Scene {
   }
 
   private renderSnapshot() {
-    if (!this.worldLayer) return;
-    this.worldLayer.removeAll(true);
+    if (!this.staticLayer || !this.markerLayer) return;
+    this.staticLayer.removeAll(true);
 
     const { locations, agents } = this.snapshot;
     if (locations.length === 0) {
+      this.clearAgentMarkers();
       return;
     }
 
@@ -86,7 +102,7 @@ export class TownScene extends Phaser.Scene {
 
     const background = this.add.rectangle(width / 2, height / 2, width, height, 0x93c5fd);
     background.setStrokeStyle(4, 0x60a5fa);
-    this.worldLayer.add(background);
+    this.staticLayer.add(background);
 
     const grid = this.add.graphics();
     grid.lineStyle(1, 0x7dd3fc, 0.4);
@@ -96,7 +112,7 @@ export class TownScene extends Phaser.Scene {
     for (let y = 0; y < height; y += GRID_SIZE) {
       grid.lineBetween(0, y, width, y);
     }
-    this.worldLayer.add(grid);
+    this.staticLayer.add(grid);
 
     const agentsByLocation = new Map<string, Agent[]>();
     for (const agent of agents) {
@@ -105,13 +121,15 @@ export class TownScene extends Phaser.Scene {
       agentsByLocation.set(agent.current_location_id, existing);
     }
 
+    const locationAnchors: LocationAnchor[] = [];
     for (const location of locations) {
       const x = (location.map_x - minX) * mapScale + PADDING_X;
       const y = (location.map_y - minY) * mapScale + PADDING_Y;
+      locationAnchors.push({ location, x, y });
 
       const tile = this.add.rectangle(x, y, TILE_SIZE, TILE_SIZE, 0xf8fafc);
       tile.setStrokeStyle(4, 0x334155);
-      this.worldLayer.add(tile);
+      this.staticLayer.add(tile);
 
       const title = this.add.text(x, y - 22, location.name, {
         color: "#0f172a",
@@ -121,7 +139,7 @@ export class TownScene extends Phaser.Scene {
         wordWrap: { width: TILE_SIZE - 8 },
       });
       title.setOrigin(0.5, 0.5);
-      this.worldLayer.add(title);
+      this.staticLayer.add(title);
 
       const idText = this.add.text(x, y + 30, location.id, {
         color: "#475569",
@@ -131,24 +149,80 @@ export class TownScene extends Phaser.Scene {
         wordWrap: { width: TILE_SIZE - 8 },
       });
       idText.setOrigin(0.5, 0.5);
-      this.worldLayer.add(idText);
+      this.staticLayer.add(idText);
+    }
 
+    this.renderAgentMarkers(locationAnchors, agentsByLocation);
+  }
+
+  private renderAgentMarkers(
+    locationAnchors: LocationAnchor[],
+    agentsByLocation: Map<string, Agent[]>,
+  ) {
+    const seenAgents = new Set<string>();
+
+    for (const { location, x, y } of locationAnchors) {
       const locationAgents = agentsByLocation.get(location.id) || [];
       locationAgents.forEach((agent, index) => {
         const offsetX = -18 + (index % 3) * 18;
         const offsetY = 8 + (index >= 3 ? 18 : 0);
-        const marker = this.add.circle(x + offsetX, y + offsetY, 10, colorForAgent(agent.id));
-        marker.setStrokeStyle(2, 0x0f172a);
-        this.worldLayer.add(marker);
-
-        const initials = this.add.text(x + offsetX, y + offsetY, getInitials(agent.name), {
-          color: "#ffffff",
-          fontSize: "9px",
-          fontFamily: "Arial",
-        });
-        initials.setOrigin(0.5, 0.5);
-        this.worldLayer.add(initials);
+        seenAgents.add(agent.id);
+        this.upsertAgentMarker(agent, x + offsetX, y + offsetY);
       });
     }
+
+    for (const [agentId, marker] of this.agentMarkers.entries()) {
+      if (!seenAgents.has(agentId)) {
+        this.tweens.killTweensOf(marker);
+        marker.destroy(true);
+        this.agentMarkers.delete(agentId);
+      }
+    }
+  }
+
+  private upsertAgentMarker(agent: Agent, x: number, y: number) {
+    let marker = this.agentMarkers.get(agent.id);
+    if (!marker) {
+      marker = this.add.container(x, y);
+
+      const circle = this.add.circle(0, 0, 10, colorForAgent(agent.id));
+      circle.setStrokeStyle(2, 0x0f172a);
+      marker.add(circle);
+
+      const initials = this.add.text(0, 0, getInitials(agent.name), {
+        color: "#ffffff",
+        fontSize: "9px",
+        fontFamily: "Arial",
+      });
+      initials.setOrigin(0.5, 0.5);
+      marker.add(initials);
+
+      this.markerLayer.add(marker);
+      this.agentMarkers.set(agent.id, marker);
+      return;
+    }
+
+    this.tweens.killTweensOf(marker);
+    const distance = Phaser.Math.Distance.Between(marker.x, marker.y, x, y);
+    if (distance < 1) {
+      marker.setPosition(x, y);
+      return;
+    }
+
+    this.tweens.add({
+      targets: marker,
+      x,
+      y,
+      duration: MARKER_TWEEN_MS,
+      ease: "Sine.easeInOut",
+    });
+  }
+
+  private clearAgentMarkers() {
+    for (const marker of this.agentMarkers.values()) {
+      this.tweens.killTweensOf(marker);
+      marker.destroy(true);
+    }
+    this.agentMarkers.clear();
   }
 }

--- a/frontend/game/TownScene.ts
+++ b/frontend/game/TownScene.ts
@@ -6,9 +6,10 @@ type TownSceneSnapshot = {
   locations: Location[];
 };
 
-const CELL = 96;
 const PADDING_X = 140;
 const PADDING_Y = 110;
+const GRID_SIZE = 96;
+const TILE_SIZE = 76;
 
 function colorForAgent(agentId: string) {
   const palette = [0x2563eb, 0xdc2626, 0x16a34a, 0x9333ea, 0xea580c, 0x0891b2];
@@ -39,12 +40,16 @@ export class TownScene extends Phaser.Scene {
   create() {
     this.cameras.main.setBackgroundColor("#9fd3ff");
     this.worldLayer = this.add.container(0, 0);
+    this.scale.on("resize", this.renderSnapshot, this);
+    this.events.once(Phaser.Scenes.Events.SHUTDOWN, () => {
+      this.scale.off("resize", this.renderSnapshot, this);
+    });
     this.renderSnapshot();
   }
 
   applySnapshot(snapshot: TownSceneSnapshot) {
     this.snapshot = snapshot;
-    if (this.scene.isActive()) {
+    if (this.worldLayer) {
       this.renderSnapshot();
     }
   }
@@ -63,8 +68,20 @@ export class TownScene extends Phaser.Scene {
     const minY = Math.min(...locations.map((location) => location.map_y));
     const maxY = Math.max(...locations.map((location) => location.map_y));
 
-    const width = (maxX - minX + 3) * CELL + PADDING_X * 2;
-    const height = (maxY - minY + 3) * CELL + PADDING_Y * 2;
+    const viewportWidth = this.scale.width || this.game.canvas.width || 960;
+    const viewportHeight = this.scale.height || this.game.canvas.height || 620;
+    const spreadX = Math.max(maxX - minX, 1);
+    const spreadY = Math.max(maxY - minY, 1);
+    const availableWidth = Math.max(viewportWidth - PADDING_X * 2, 1);
+    const availableHeight = Math.max(viewportHeight - PADDING_Y * 2, 1);
+    const mapScale = Math.min(
+      availableWidth / spreadX,
+      availableHeight / spreadY,
+      1,
+    );
+
+    const width = viewportWidth;
+    const height = viewportHeight;
     this.cameras.main.setBounds(0, 0, width, height);
 
     const background = this.add.rectangle(width / 2, height / 2, width, height, 0x93c5fd);
@@ -73,10 +90,10 @@ export class TownScene extends Phaser.Scene {
 
     const grid = this.add.graphics();
     grid.lineStyle(1, 0x7dd3fc, 0.4);
-    for (let x = 0; x < width; x += CELL) {
+    for (let x = 0; x < width; x += GRID_SIZE) {
       grid.lineBetween(x, 0, x, height);
     }
-    for (let y = 0; y < height; y += CELL) {
+    for (let y = 0; y < height; y += GRID_SIZE) {
       grid.lineBetween(0, y, width, y);
     }
     this.worldLayer.add(grid);
@@ -89,10 +106,10 @@ export class TownScene extends Phaser.Scene {
     }
 
     for (const location of locations) {
-      const x = (location.map_x - minX + 1) * CELL + PADDING_X;
-      const y = (location.map_y - minY + 1) * CELL + PADDING_Y;
+      const x = (location.map_x - minX) * mapScale + PADDING_X;
+      const y = (location.map_y - minY) * mapScale + PADDING_Y;
 
-      const tile = this.add.rectangle(x, y, 76, 76, 0xf8fafc);
+      const tile = this.add.rectangle(x, y, TILE_SIZE, TILE_SIZE, 0xf8fafc);
       tile.setStrokeStyle(4, 0x334155);
       this.worldLayer.add(tile);
 

--- a/frontend/game/TownScene.ts
+++ b/frontend/game/TownScene.ts
@@ -113,21 +113,22 @@ export class TownScene extends Phaser.Scene {
       tile.setStrokeStyle(4, 0x334155);
       this.worldLayer.add(tile);
 
-      const title = this.add.text(x, y - 58, location.name, {
+      const title = this.add.text(x, y - 22, location.name, {
         color: "#0f172a",
-        fontSize: "14px",
+        fontSize: "10px",
         fontFamily: "Arial",
         align: "center",
-        wordWrap: { width: 120 },
+        wordWrap: { width: TILE_SIZE - 8 },
       });
       title.setOrigin(0.5, 0.5);
       this.worldLayer.add(title);
 
-      const idText = this.add.text(x, y + 50, location.id, {
+      const idText = this.add.text(x, y + 30, location.id, {
         color: "#475569",
-        fontSize: "10px",
+        fontSize: "7px",
         fontFamily: "Consolas",
         align: "center",
+        wordWrap: { width: TILE_SIZE - 8 },
       });
       idText.setOrigin(0.5, 0.5);
       this.worldLayer.add(idText);
@@ -135,7 +136,7 @@ export class TownScene extends Phaser.Scene {
       const locationAgents = agentsByLocation.get(location.id) || [];
       locationAgents.forEach((agent, index) => {
         const offsetX = -18 + (index % 3) * 18;
-        const offsetY = index >= 3 ? 18 : 0;
+        const offsetY = 8 + (index >= 3 ? 18 : 0);
         const marker = this.add.circle(x + offsetX, y + offsetY, 10, colorForAgent(agent.id));
         marker.setStrokeStyle(2, 0x0f172a);
         this.worldLayer.add(marker);

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -1,4 +1,4 @@
-import { Agent, ApiResponse, BootstrapSnapshot, Location, WorldTime } from "@/types/world";
+import { Agent, ApiResponse, BootstrapSnapshot, Location, SimEvent, WorldEventEnvelope, WorldTime } from "@/types/world";
 
 function getApiBase() {
   if (process.env.NEXT_PUBLIC_API_URL) {
@@ -31,14 +31,36 @@ export async function fetchWorldTime(): Promise<WorldTime> {
   return fetchJson<WorldTime>("/world/time");
 }
 
+function eventToEnvelope(event: SimEvent): WorldEventEnvelope {
+  return {
+    id: `event:${event.id}`,
+    ts: event.occurred_at,
+    type: event.type,
+    agent_targets: event.actor_id ? [event.actor_id] : [],
+    location_id: event.location_id,
+    payload: {
+      actor_id: event.actor_id,
+      description: event.description,
+      metadata: event.metadata,
+      source: "history",
+    },
+  };
+}
+
+export async function fetchRecentEvents(limit = 20): Promise<WorldEventEnvelope[]> {
+  const events = await fetchJson<SimEvent[]>(`/events?limit=${limit}`);
+  return events.map(eventToEnvelope);
+}
+
 export async function fetchBootstrapSnapshot(): Promise<BootstrapSnapshot> {
-  const [agents, locations, worldTime] = await Promise.all([
+  const [agents, locations, worldTime, recentEvents] = await Promise.all([
     fetchAgents(),
     fetchLocations(),
     fetchWorldTime(),
+    fetchRecentEvents(),
   ]);
 
-  return { agents, locations, worldTime };
+  return { agents, locations, worldTime, recentEvents };
 }
 
 export function getWsUrl() {

--- a/frontend/lib/sim-store.ts
+++ b/frontend/lib/sim-store.ts
@@ -64,6 +64,7 @@ export function simReducer(state: SimState, action: SimAction): SimState {
         agents: action.payload.agents,
         locations: action.payload.locations,
         worldTime: action.payload.worldTime,
+        recentEvents: action.payload.recentEvents,
         loading: false,
         error: null,
         lastSnapshotAt: new Date().toISOString(),

--- a/frontend/types/world.ts
+++ b/frontend/types/world.ts
@@ -57,10 +57,21 @@ export type WorldEventEnvelope = {
   payload: Record<string, unknown>;
 };
 
+export type SimEvent = {
+  id: number;
+  occurred_at: string;
+  type: string;
+  actor_id: string | null;
+  location_id: string | null;
+  description: string;
+  metadata: Record<string, unknown>;
+};
+
 export type BootstrapSnapshot = {
   agents: Agent[];
   locations: Location[];
   worldTime: WorldTime;
+  recentEvents: WorldEventEnvelope[];
 };
 
 export type SimConnectionState = "idle" | "loading" | "open" | "closed" | "error";

--- a/world-api/src/main.rs
+++ b/world-api/src/main.rs
@@ -73,7 +73,7 @@ async fn main() -> AppResult<()> {
         .route("/world/time", get(get_world_time))
         .route("/locations/:id", get(get_location_by_id))
         .route("/locations/:id/nearby", get(get_nearby_locations))
-        .route("/objects/:location_id", get(list_objects_by_location))
+        .route("/locations/:location_id/objects", get(list_objects_by_location))
         .route("/objects/:id", patch(update_object_state))
         .route("/pathfind", get(get_path))
         .route("/agents", get(list_agents))

--- a/world-api/src/routes/agents.rs
+++ b/world-api/src/routes/agents.rs
@@ -63,16 +63,7 @@ pub async fn list_agents(
 ) -> AppResult<Json<ApiResponse<Vec<Agent>>>> {
     let agents = sqlx::query_as::<_, Agent>(
         r#"
-        SELECT
-            id,
-            name,
-            occupation,
-            current_location_id,
-            state,
-            current_activity,
-            is_npc,
-            is_active,
-            state_updated_at
+        SELECT *
         FROM agents
         ORDER BY name
         "#,
@@ -89,16 +80,7 @@ pub async fn get_agent_by_id(
 ) -> AppResult<Json<ApiResponse<Agent>>> {
     let agent = sqlx::query_as::<_, Agent>(
         r#"
-        SELECT
-            id,
-            name,
-            occupation,
-            current_location_id,
-            state,
-            current_activity,
-            is_npc,
-            is_active,
-            state_updated_at
+        SELECT *
         FROM agents
         WHERE id = $1
         "#,
@@ -208,16 +190,7 @@ async fn perform_agent_location_update(
             state_updated_at = NOW(),
             updated_at = NOW()
         WHERE id = $2
-        RETURNING
-            id,
-            name,
-            occupation,
-            current_location_id,
-            state,
-            current_activity,
-            is_npc,
-            is_active,
-            state_updated_at
+        RETURNING *
         "#,
     )
     .bind(location_id)
@@ -327,16 +300,7 @@ pub async fn update_agent_activity(
             state_updated_at = NOW(),
             updated_at = NOW()
         WHERE id = $2
-        RETURNING
-            id,
-            name,
-            occupation,
-            current_location_id,
-            state,
-            current_activity,
-            is_npc,
-            is_active,
-            state_updated_at
+        RETURNING *
         "#,
     )
     .bind(&payload.activity)
@@ -385,16 +349,7 @@ pub async fn clear_agent_activity(
             state_updated_at = NOW(),
             updated_at = NOW()
         WHERE id = $1
-        RETURNING
-            id,
-            name,
-            occupation,
-            current_location_id,
-            state,
-            current_activity,
-            is_npc,
-            is_active,
-            state_updated_at
+        RETURNING *
         "#,
     )
     .bind(&agent_id)


### PR DESCRIPTION
## Summary
- Keep static map elements and agent markers on separate Phaser layers.
- Preserve marker containers across snapshot redraws so location changes can tween instead of snapping.
- Kill and restart marker tweens on rapid updates so new websocket events do not leave stale animations running.

Stacked on #36. The final diff should shrink once #36 lands.

Refs #28.

Checked with `npm run build` and a bundled-app smoke test on port 3004.

"Let the dots walk a little."

Written by Cameron ◯ Letta Code