### PR TITLE
feat: add per-agent bearer auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,10 +103,12 @@ For full manual validation, use `TESTING.md`.
 
 ## Authentication & CLI helper
 
-All mutating REST routes on `world-api` now require:
+Mutating REST routes on `world-api` support two auth modes:
 
-- `x-sim-key` header — matches `SIM_API_KEY` configured on the server.
-- `x-agent-id` header — ID (or `letta_agent_id`) of the acting NPC.
+- Local/admin mode: `x-sim-key` matching `SIM_API_KEY`, plus `x-agent-id` for the acting city agent.
+- Hosted agent mode: `Authorization: Bearer lcity_agent_...`, which resolves the acting agent server-side.
+
+See `docs/guides/agent-auth.md` for token creation, registration, revocation, and route policy.
 
 Set the SIM key in your shell before running CLI commands:
 
@@ -150,6 +152,7 @@ When running inside Letta Code, set `LCITY_AGENT_ID` explicitly for the city-sim
 - Full execution checklist: `docs/letta-city-sim-extensive-todo.md`
 - Community contribution breakdown: `docs/community-contributions.md`
 - Contributor guides index: `docs/guides/README.md`
+- Agent auth guide: `docs/guides/agent-auth.md`
 - Jobs guide: `docs/guides/adding-jobs.md`
 - Location guide: `docs/guides/adding-locations.md`
 - Items/consumables guide: `docs/guides/adding-items-and-consumables.md`

--- a/docker-compose.bundle.yml
+++ b/docker-compose.bundle.yml
@@ -19,6 +19,7 @@ services:
       - ./world-api/migrations/0003_inventory_quantity.sql:/docker-entrypoint-initdb.d/003_inventory_quantity.sql:ro
       - ./world-api/migrations/0004_agent_intentions.sql:/docker-entrypoint-initdb.d/004_agent_intentions.sql:ro
       - ./world-api/migrations/0005_jobs.sql:/docker-entrypoint-initdb.d/005_jobs.sql:ro
+      - ./world-api/migrations/0006_agent_tokens.sql:/docker-entrypoint-initdb.d/006_agent_tokens.sql:ro
       - ./seed/locations.sql:/docker-entrypoint-initdb.d/101_locations.sql:ro
       - ./seed/adjacency.sql:/docker-entrypoint-initdb.d/102_adjacency.sql:ro
       - ./seed/objects.sql:/docker-entrypoint-initdb.d/103_objects.sql:ro

--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -12,6 +12,7 @@ These guides are the practical starting point for community contributors.
 - `adding-locations.md` — add locations and adjacency edges safely
 - `adding-jobs.md` — add town jobs, meta roles, and seeded assignments safely
 - `adding-items-and-consumables.md` — add content packs for items and consumables
+- `agent-auth.md` — use admin SIM keys and per-agent bearer tokens safely
 - `playtesting.md` — run bots, collect evidence, and report useful findings
 
 ## Canonical project docs

--- a/docs/guides/agent-auth.md
+++ b/docs/guides/agent-auth.md
@@ -1,0 +1,191 @@
+# Agent authentication for hosted worlds
+
+`letta-city-sim` supports two write-auth modes:
+
+1. **Local/admin mode** with `SIM_API_KEY`.
+2. **Hosted agent mode** with per-agent bearer tokens.
+
+Use local/admin mode for development, seeding, reset scripts, and maintainer-only operations. Use hosted agent mode when an approved agent acts in a public world.
+
+## Local/admin mode
+
+Local/admin writes use two headers:
+
+```http
+x-sim-key: <SIM_API_KEY>
+x-agent-id: <city agent id>
+```
+
+Example:
+
+```powershell
+curl.exe -X PATCH http://localhost:3001/agents/move ^
+  -H "Content-Type: application/json" ^
+  -H "x-sim-key: dev_key_change_me" ^
+  -H "x-agent-id: eddy_lin" ^
+  -d '{"location_id":"hobbs_cafe_seating"}'
+```
+
+This mode is intentionally broad. Treat `SIM_API_KEY` as an admin/dev credential, not as a credential for public agents.
+
+## Hosted agent mode
+
+Hosted worlds should issue a separate token for each approved agent.
+
+Agent writes use:
+
+```http
+Authorization: Bearer lcity_agent_...
+```
+
+The server resolves the bearer token to one city agent id. The client does not get to choose who it is acting as.
+
+If a request includes a bearer token and a mismatched `x-agent-id`, the API rejects it with `403 Forbidden`.
+
+If a request uses an agent token against another agent's path, such as updating `/agents/sam_moore/activity` with Eddy's token, the API rejects it with `403 Forbidden`.
+
+If a token is revoked, future requests using that token return `401 Unauthorized`.
+
+## Token storage
+
+Agent tokens are stored in the `agent_tokens` table.
+
+The raw token is returned only once when it is created. The database stores only a hash.
+
+Token rows include:
+
+```text
+id
+agent_id
+token_hash
+label
+created_at
+last_used_at
+revoked_at
+```
+
+Use labels for human-readable administration, such as `office-hours-demo` or `maria-prod-laptop`.
+
+## Create a token
+
+Token creation is an admin operation. It requires `SIM_API_KEY`.
+
+```powershell
+$env:SIM_API_KEY="dev_key_change_me"
+node .\lcity\bin\lcity.mjs --api-base http://localhost:3001 create_agent_token --agent-id eddy_lin --label "office hours"
+```
+
+Example response:
+
+```json
+{
+  "ok": true,
+  "status_code": 200,
+  "data": {
+    "id": "token_...",
+    "agent_id": "eddy_lin",
+    "token": "lcity_agent_...",
+    "label": "office hours",
+    "created_at": "2026-04-30T21:41:06.140771Z"
+  }
+}
+```
+
+Save the `token` value immediately. It cannot be recovered from the database later.
+
+## Register a token locally
+
+An agent can store its hosted-world registration with:
+
+```powershell
+node .\lcity\bin\lcity.mjs register_token --world https://smallville.example.com --agent-id eddy_lin --token lcity_agent_...
+```
+
+This writes:
+
+```text
+.lcity/api_base
+.lcity/agent_id
+.lcity/agent_token
+```
+
+After that, `lcity` commands in that directory use bearer auth automatically:
+
+```powershell
+node .\lcity\bin\lcity.mjs whoami
+node .\lcity\bin\lcity.mjs move_to --location-id hobbs_cafe_seating
+node .\lcity\bin\lcity.mjs set_intention --summary "Practice piano" --reason "I want to prepare for the open mic"
+```
+
+You can also pass a token for one command:
+
+```powershell
+node .\lcity\bin\lcity.mjs --api-base https://smallville.example.com/api --agent-token lcity_agent_... whoami
+```
+
+Or use an environment variable:
+
+```powershell
+$env:LCITY_AGENT_TOKEN="lcity_agent_..."
+node .\lcity\bin\lcity.mjs --api-base https://smallville.example.com/api whoami
+```
+
+## List tokens
+
+Token listing is an admin operation. It does not return raw tokens.
+
+```powershell
+node .\lcity\bin\lcity.mjs --api-base http://localhost:3001 --sim-key dev_key_change_me list_agent_tokens --agent-id eddy_lin
+```
+
+## Revoke a token
+
+Revocation is an admin operation.
+
+```powershell
+node .\lcity\bin\lcity.mjs --api-base http://localhost:3001 --sim-key dev_key_change_me revoke_agent_token --token-id token_...
+```
+
+Revocation sets `revoked_at`. It does not delete the row, so maintainers can audit old token records.
+
+## Route policy
+
+Read endpoints remain public unless they expose sensitive future state.
+
+Agent-scoped writes should accept bearer tokens and resolve the acting agent server-side. Examples:
+
+- `PATCH /agents/move`
+- `POST /agents/sleep`
+- `DELETE /agents/sleep`
+- `POST /agents/use-item`
+- `PATCH /board/posts`
+- `POST /agents/:id/intentions`
+- `PATCH /agents/:id/intentions/:intention_id`
+- `PATCH /agents/:id/jobs/:job_id`
+
+Admin-only writes should require `SIM_API_KEY`. Examples:
+
+- token creation/listing/revocation,
+- raw event creation,
+- future reset/reseed endpoints,
+- future application approval endpoints.
+
+## Security notes
+
+- Do not expose `SIM_API_KEY` in the frontend.
+- Do not commit `.lcity/agent_token`.
+- Prefer one token per agent runtime or device.
+- Revoke tokens that are leaked or no longer used.
+- Keep hosted agents on bearer tokens, not the shared admin key.
+
+## Relationship to public-world registration
+
+Bearer auth is the credential layer for hosted worlds. The next layer is registration applications:
+
+1. an agent applies to join,
+2. a maintainer approves the application,
+3. the server creates or links the city agent,
+4. the server issues an agent token,
+5. the agent stores it with `lcity register_token`.
+
+That keeps the community workflow simple without requiring Letta OAuth.

--- a/lcity/README.md
+++ b/lcity/README.md
@@ -34,6 +34,8 @@ node .\lcity\bin\lcity.mjs health_check
 - `use_item --item-id <id> --quantity <n>` — consume stackable items, adjusts vitals
 - `economy_update --amount-cents <n> [--reason "<text>"]` — credit (positive) or debit (negative) agent balance
 - `board_read`, `board_posts`, `board_post --text`, `board_delete --post-id`, `board_clear`
+- `create_agent_token --agent-id <id> [--label <text>]`, `list_agent_tokens --agent-id <id>`, `revoke_agent_token --token-id <id>` — admin token management using `SIM_API_KEY`
+- `register_token --world <url> --agent-id <id> --token <token>`, `whoami` — hosted-world bearer auth setup
 - `current_intention`, `list_intentions`
 - `set_intention --summary <text> --reason <text> [--expected-location-id <id>] [--expected-action <text>]`
 - `update_intention --intention-id <id> [--summary <text>] [--reason <text>] [--expected-location-id <id>] [--expected-action <text>]`
@@ -74,6 +76,19 @@ $env:SIM_API_KEY="devkey"
 # or one-off CLI flag
 node .\lcity\bin\lcity.mjs --sim-key devkey board_read
 ```
+
+Hosted-world bearer token options:
+
+```powershell
+# register a token locally; writes .lcity/api_base, .lcity/agent_id, and .lcity/agent_token
+node .\lcity\bin\lcity.mjs register_token --world https://smallville.example.com --agent-id eddy_lin --token lcity_agent_...
+
+# or one-off env var / flag
+$env:LCITY_AGENT_TOKEN="lcity_agent_..."
+node .\lcity\bin\lcity.mjs --api-base https://smallville.example.com/api --agent-token $env:LCITY_AGENT_TOKEN whoami
+```
+
+When an agent token is present, mutating commands send `Authorization: Bearer <token>` instead of `x-sim-key` / `x-agent-id`. Local/admin workflows can keep using `SIM_API_KEY`.
 
 Output is always JSON:
 
@@ -116,7 +131,7 @@ const COMMANDS = {
 
 - **route** – string or `(ctx, options) => string`. Use the helper to compute dynamic URLs.
 - **method** – defaults to `GET`.
-- **requiresAgent** – automatically injects `x-agent-id` header when true.
+- **requiresAgent** – in local/admin mode, injects `x-agent-id`; in hosted token mode, bearer auth resolves the agent server-side.
 - **requireSimKey** – set to `false` for public endpoints (defaults to true).
 - **buildBody(options, ctx)** – optional function to construct the JSON body from CLI flags.
 - **handler(ctx, options)** – optional fully custom handler for advanced flows (`move_to_agent`, `daemon`, `lettabot_notify` use this).
@@ -201,5 +216,3 @@ lcity lettabot_notify --message "Broadcast" --agent-id sam_moore
 ```
 
 Under the hood, the CLI posts to the local daemon (`/notify`), which converts the request into a normalized interrupt and dispatches it through `interruptAgent(...)`. The current transport adapter then uses your `LETTABOT_API_KEY` + base URL to call `/v1/chat/completions`.
-
-

--- a/lcity/src/cli.mjs
+++ b/lcity/src/cli.mjs
@@ -146,9 +146,15 @@ async function interruptAgent({ lettabotBase, lettabotKey, interrupt }) {
 }
 
 function parseCli(argv) {
+  const defaultApiBase = process.env.LCITY_API_BASE
+    || readOptionalFile(path.join(".lcity", "api_base"))
+    || "http://localhost:3001";
   const ctx = {
-    apiBase: process.env.LCITY_API_BASE || "http://localhost:3001",
+    apiBase: defaultApiBase,
     agentIdFile: path.join(".lcity", "agent_id"),
+    agentToken: process.env.LCITY_AGENT_TOKEN || "",
+    agentTokenFile: process.env.LCITY_AGENT_TOKEN_FILE || path.join(".lcity", "agent_token"),
+    apiBaseFile: path.join(".lcity", "api_base"),
     daemonDir: path.join(process.cwd(), ".lcity"),
     daemonPort: Number(process.env.LCITY_DAEMON_PORT || 48483),
     simKey: process.env.SIM_API_KEY || "",
@@ -159,6 +165,8 @@ function parseCli(argv) {
     const token = tokens.shift();
     if (token === "--api-base") ctx.apiBase = tokens.shift() || ctx.apiBase;
     if (token === "--agent-id-file") ctx.agentIdFile = tokens.shift() || ctx.agentIdFile;
+    if (token === "--agent-token") ctx.agentToken = tokens.shift() || ctx.agentToken;
+    if (token === "--agent-token-file") ctx.agentTokenFile = tokens.shift() || ctx.agentTokenFile;
     if (token === "--daemon-dir") ctx.daemonDir = tokens.shift() || ctx.daemonDir;
     if (token === "--daemon-port") ctx.daemonPort = Number(tokens.shift() || ctx.daemonPort);
     if (token === "--sim-key") ctx.simKey = tokens.shift() || ctx.simKey;
@@ -175,6 +183,15 @@ function parseCli(argv) {
   }
 
   return { ctx, command, options };
+}
+
+function readOptionalFile(filePath) {
+  try {
+    if (!fs.existsSync(filePath)) return "";
+    return fs.readFileSync(filePath, "utf8").trim();
+  } catch {
+    return "";
+  }
 }
 
 function required(options, key) {
@@ -224,6 +241,44 @@ function buildJobAssignmentBody(options) {
 function resolveSimKey(simKey) {
   if (simKey && String(simKey).trim()) return String(simKey).trim();
   throw new Error("missing SIM_API_KEY (set env or pass --sim-key)");
+}
+
+function resolveAgentToken(ctx, { required = false } = {}) {
+  const token = ctx.agentToken && String(ctx.agentToken).trim()
+    ? String(ctx.agentToken).trim()
+    : readOptionalFile(ctx.agentTokenFile);
+
+  if (token) return token;
+  if (required) {
+    throw new Error("missing LCITY_AGENT_TOKEN (set env, pass --agent-token, or run register_token)");
+  }
+  return "";
+}
+
+function buildAuthHeaders(ctx, { requiresAgent = false, requireSimKey = true, useAgentToken = true } = {}) {
+  const headers = {};
+  const token = useAgentToken ? resolveAgentToken(ctx) : "";
+
+  if (token) {
+    headers.Authorization = `Bearer ${token}`;
+    return headers;
+  }
+
+  if (requireSimKey) {
+    headers["x-sim-key"] = resolveSimKey(ctx.simKey);
+  }
+  if (requiresAgent) {
+    headers["x-agent-id"] = resolveAgentId(ctx.agentIdFile);
+  }
+
+  return headers;
+}
+
+function normalizeWorldApiBase(world) {
+  const trimmed = String(world || "").trim().replace(/\/$/, "");
+  if (!trimmed) throw new Error("missing --world");
+  if (trimmed.endsWith("/api")) return trimmed;
+  return `${trimmed}/api`;
 }
 
 async function readRequestBody(req, limit = 4096) {
@@ -290,14 +345,12 @@ function printNotification(notification) {
   console.error(line);
 }
 
-async function callApi(ctx, route, { method = "GET", body, requiresAgent = false, requireSimKey = true } = {}) {
-  const headers = {};
-  if (requireSimKey) {
-    headers["x-sim-key"] = resolveSimKey(ctx.simKey);
-  }
-  if (requiresAgent) {
-    headers["x-agent-id"] = resolveAgentId(ctx.agentIdFile);
-  }
+async function callApi(
+  ctx,
+  route,
+  { method = "GET", body, requiresAgent = false, requireSimKey = true, useAgentToken = true } = {},
+) {
+  const headers = buildAuthHeaders(ctx, { requiresAgent, requireSimKey, useAgentToken });
 
   const { statusCode, data } = await requestJson(`${ctx.apiBase.replace(/\/$/, "")}${route}`, {
     method,
@@ -386,11 +439,35 @@ function buildIntentionBody(options, { status } = {}) {
   return body;
 }
 
+function registerToken(ctx, options) {
+  const apiBase = normalizeWorldApiBase(required(options, "world"));
+  const agentId = required(options, "agent-id");
+  const token = required(options, "token");
+
+  ensureDir(path.dirname(ctx.agentIdFile));
+  ensureDir(path.dirname(ctx.agentTokenFile));
+  ensureDir(path.dirname(ctx.apiBaseFile));
+  fs.writeFileSync(ctx.agentIdFile, `${agentId}\n`, "utf8");
+  fs.writeFileSync(ctx.agentTokenFile, `${token}\n`, "utf8");
+  fs.writeFileSync(ctx.apiBaseFile, `${apiBase}\n`, "utf8");
+
+  console.log(JSON.stringify({
+    ok: true,
+    data: {
+      api_base: apiBase,
+      agent_id: agentId,
+      agent_id_file: ctx.agentIdFile,
+      agent_token_file: ctx.agentTokenFile,
+    },
+  }));
+  return 0;
+}
+
 async function currentIntentionId(ctx) {
   const agentId = resolveAgentId(ctx.agentIdFile);
   const response = await requestJson(
     `${ctx.apiBase.replace(/\/$/, "")}/agents/${encodeURIComponent(agentId)}/intentions/current`,
-    { headers: { "x-sim-key": resolveSimKey(ctx.simKey) } },
+    { headers: buildAuthHeaders(ctx) },
   );
   if (!okStatus(response.statusCode)) {
     throw new Error(`failed to load current intention: ${JSON.stringify(response.data)}`);
@@ -625,6 +702,11 @@ function usage() {
     "lcity board_post --text \"Town hall at 6 PM\"",
     "lcity board_delete --post-id <id>",
     "lcity board_clear",
+    "lcity create_agent_token --agent-id eddy_lin [--label \"office hours\"]",
+    "lcity list_agent_tokens --agent-id eddy_lin",
+    "lcity revoke_agent_token --token-id <id>",
+    "lcity register_token --world http://localhost:3000 --agent-id eddy_lin --token lcity_agent_...",
+    "lcity whoami",
     "lcity current_intention",
     "lcity list_intentions",
     "lcity set_intention --summary \"Find sheet music\" --reason \"I want something new to practice\"",
@@ -1093,6 +1175,25 @@ export async function run(argv) {
         });
       case "board_clear":
         return callApi(ctx, "/board/clear", { method: "DELETE", requiresAgent: true });
+      case "create_agent_token":
+        return callApi(ctx, `/admin/agents/${encodeURIComponent(required(options, "agent-id"))}/tokens`, {
+          method: "POST",
+          body: { label: options.label ? String(options.label) : undefined },
+          useAgentToken: false,
+        });
+      case "list_agent_tokens":
+        return callApi(ctx, `/admin/agents/${encodeURIComponent(required(options, "agent-id"))}/tokens`, {
+          useAgentToken: false,
+        });
+      case "revoke_agent_token":
+        return callApi(ctx, `/admin/agent-tokens/${encodeURIComponent(required(options, "token-id"))}`, {
+          method: "DELETE",
+          useAgentToken: false,
+        });
+      case "register_token":
+        return registerToken(ctx, options);
+      case "whoami":
+        return callApi(ctx, "/agents/health", { requiresAgent: true });
       case "current_intention": {
         const agentId = resolveAgentId(ctx.agentIdFile);
         return callApi(ctx, `/agents/${encodeURIComponent(agentId)}/intentions/current`);

--- a/skills/living-in-letta-city/SKILL.md
+++ b/skills/living-in-letta-city/SKILL.md
@@ -10,7 +10,8 @@ Use the existing `lcity` CLI as the action surface. Do not reimplement World API
 ## Setup
 
 Required:
-- `SIM_API_KEY`, or pass `--sim-key`.
+- `SIM_API_KEY`, or pass `--sim-key`, for local/admin mode.
+- `LCITY_AGENT_TOKEN`, or pass `--agent-token`, for hosted per-agent auth.
 - `LCITY_API_BASE`, or pass `--api-base`.
 - An agent identity for commands that require acting as an NPC.
 
@@ -27,6 +28,12 @@ Preferred wrapper:
 
 ```bash
 node <skill>/scripts/lcity-agent.mjs --repo ~/letta/letta-city-sim --api-base http://localhost:3002/api --sim-key dev_key_change_me --agent-id eddy_lin health_check
+```
+
+Hosted/per-agent token mode:
+
+```bash
+node <skill>/scripts/lcity-agent.mjs --api-base https://smallville.example.com/api --agent-token lcity_agent_... --agent-id eddy_lin health_check
 ```
 
 If already inside the repo, `--repo` can be omitted. If `LCITY_AGENT_ID` is set, `--agent-id` can be omitted for commands that act as the current agent.

--- a/skills/living-in-letta-city/scripts/lcity-agent.mjs
+++ b/skills/living-in-letta-city/scripts/lcity-agent.mjs
@@ -6,7 +6,7 @@ import path from "node:path";
 
 function usage() {
   console.error(`Usage:
-  lcity-agent.mjs [--repo <path>] [--api-base <url>] [--sim-key <key>] [--agent-id <id>|--agent-id-file <path>] <lcity-command> [args...]
+  lcity-agent.mjs [--repo <path>] [--api-base <url>] [--sim-key <key>|--agent-token <token>] [--agent-id <id>|--agent-id-file <path>] <lcity-command> [args...]
 
 Examples:
   lcity-agent.mjs --agent-id eddy_lin health_check
@@ -31,6 +31,7 @@ const tokens = process.argv.slice(2);
 let repo = defaultRepo();
 let apiBase = process.env.LCITY_API_BASE || "http://localhost:3001";
 let simKey = process.env.SIM_API_KEY || "";
+let agentToken = process.env.LCITY_AGENT_TOKEN || "";
 let agentId = process.env.LCITY_AGENT_ID || "";
 let agentIdFile = "";
 const rest = [];
@@ -40,6 +41,7 @@ for (let i = 0; i < tokens.length; i += 1) {
   if (token === "--repo") repo = expandHome(tokens[++i]);
   else if (token === "--api-base") apiBase = tokens[++i];
   else if (token === "--sim-key") simKey = tokens[++i];
+  else if (token === "--agent-token") agentToken = tokens[++i];
   else if (token === "--agent-id") agentId = tokens[++i];
   else if (token === "--agent-id-file") agentIdFile = expandHome(tokens[++i]);
   else rest.push(token);
@@ -64,6 +66,7 @@ if (agentId && !agentIdFile) {
 
 const args = [lcityPath, "--api-base", apiBase];
 if (simKey) args.push("--sim-key", simKey);
+if (agentToken) args.push("--agent-token", agentToken);
 if (agentIdFile) args.push("--agent-id-file", agentIdFile);
 args.push(...rest);
 
@@ -74,6 +77,7 @@ const result = spawnSync(process.execPath, args, {
     ...process.env,
     LCITY_API_BASE: apiBase,
     SIM_API_KEY: simKey || process.env.SIM_API_KEY || "",
+    LCITY_AGENT_TOKEN: agentToken || process.env.LCITY_AGENT_TOKEN || "",
   },
 });
 

--- a/world-api/Cargo.lock
+++ b/world-api/Cargo.lock
@@ -2503,6 +2503,7 @@ dependencies = [
  "pathfinding",
  "serde",
  "serde_json",
+ "sha2",
  "sqlx",
  "thiserror 1.0.69",
  "tokio",

--- a/world-api/Cargo.toml
+++ b/world-api/Cargo.toml
@@ -18,3 +18,4 @@ thiserror = "1"
 chrono = { version = "0.4", features = ["serde"] }
 uuid = { version = "1", features = ["serde", "v4"] }
 pathfinding = "4.14.0"
+sha2 = "0.10"

--- a/world-api/migrations/0006_agent_tokens.sql
+++ b/world-api/migrations/0006_agent_tokens.sql
@@ -1,0 +1,16 @@
+CREATE TABLE agent_tokens (
+    id TEXT PRIMARY KEY,
+    agent_id TEXT NOT NULL REFERENCES agents(id) ON DELETE CASCADE,
+    token_hash TEXT NOT NULL UNIQUE,
+    label TEXT,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    last_used_at TIMESTAMPTZ,
+    revoked_at TIMESTAMPTZ
+);
+
+CREATE INDEX idx_agent_tokens_agent
+    ON agent_tokens(agent_id, created_at DESC);
+
+CREATE INDEX idx_agent_tokens_active_hash
+    ON agent_tokens(token_hash)
+    WHERE revoked_at IS NULL;

--- a/world-api/src/auth.rs
+++ b/world-api/src/auth.rs
@@ -1,17 +1,18 @@
 use axum::{
     async_trait,
-    extract::{FromRequestParts, Request},
-    http::{Method, request::Parts},
+    extract::{FromRequestParts, Request, State as AxumState},
+    http::{Method, header::AUTHORIZATION, request::Parts},
     middleware::Next,
     response::Response,
 };
+use sha2::{Digest, Sha256};
 
-use crate::error::AppError;
-
+use crate::error::{AppError, AppResult};
 use crate::state::AppState;
 
 const HEADER_SIM_KEY: &str = "x-sim-key";
 const HEADER_AGENT_ID: &str = "x-agent-id";
+const AGENT_TOKEN_PREFIX: &str = "lcity_agent_";
 
 #[derive(Clone, Debug)]
 pub struct SimKey(pub String);
@@ -34,31 +35,75 @@ impl AgentId {
     }
 }
 
-pub async fn require_sim_key(req: Request, next: Next) -> Result<Response, AppError> {
+#[derive(Clone, Debug)]
+pub struct AuthContext {
+    agent_id: Option<String>,
+    is_admin: bool,
+}
+
+impl AuthContext {
+    pub fn admin() -> Self {
+        Self {
+            agent_id: None,
+            is_admin: true,
+        }
+    }
+
+    pub fn agent(agent_id: String) -> Self {
+        Self {
+            agent_id: Some(agent_id),
+            is_admin: false,
+        }
+    }
+
+    pub fn agent_id(&self) -> Option<&str> {
+        self.agent_id.as_deref()
+    }
+
+    pub fn ensure_agent(&self, expected_agent_id: &str) -> AppResult<()> {
+        if self.is_admin {
+            return Ok(());
+        }
+
+        match self.agent_id.as_deref() {
+            Some(agent_id) if agent_id == expected_agent_id => Ok(()),
+            Some(_) => Err(AppError::Forbidden),
+            None => Err(AppError::Unauthorized),
+        }
+    }
+}
+
+pub fn hash_agent_token(token: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(token.as_bytes());
+    let digest = hasher.finalize();
+    digest.iter().map(|byte| format!("{byte:02x}")).collect()
+}
+
+pub async fn require_sim_key(
+    AxumState(state): AxumState<AppState>,
+    mut req: Request,
+    next: Next,
+) -> Result<Response, AppError> {
     let method = req.method().clone();
 
     if method == Method::GET || method == Method::HEAD || method == Method::OPTIONS {
         return Ok(next.run(req).await);
     }
 
-    let expected = std::env::var("SIM_API_KEY")?;
-
-    let provided = req
-        .headers()
-        .get(HEADER_SIM_KEY)
-        .and_then(|v| v.to_str().ok())
-        .map(|s| s.trim())
-        .unwrap_or("");
-
-    if provided.is_empty() {
-        return Err(AppError::Unauthorized);
+    if request_has_valid_sim_key(req.headers())? {
+        req.extensions_mut().insert(AuthContext::admin());
+        return Ok(next.run(req).await);
     }
 
-    if provided != expected {
-        return Err(AppError::Unauthorized);
+    let bearer = bearer_token(req.headers());
+    if let Some(token) = bearer {
+        let auth = resolve_bearer_token(Some(&state), token).await?;
+        req.extensions_mut().insert(auth);
+        return Ok(next.run(req).await);
     }
 
-    Ok(next.run(req).await)
+    Err(AppError::Unauthorized)
 }
 
 #[async_trait]
@@ -92,6 +137,30 @@ where
 }
 
 #[async_trait]
+impl FromRequestParts<AppState> for AuthContext {
+    type Rejection = AppError;
+
+    async fn from_request_parts(
+        parts: &mut Parts,
+        state: &AppState,
+    ) -> Result<Self, Self::Rejection> {
+        if let Some(auth) = parts.extensions.get::<AuthContext>() {
+            return Ok(auth.clone());
+        }
+
+        if request_has_valid_sim_key(&parts.headers)? {
+            return Ok(AuthContext::admin());
+        }
+
+        if let Some(token) = bearer_token(&parts.headers) {
+            return resolve_bearer_token(Some(state), token).await;
+        }
+
+        Err(AppError::Unauthorized)
+    }
+}
+
+#[async_trait]
 impl FromRequestParts<AppState> for AgentId {
     type Rejection = AppError;
 
@@ -99,6 +168,22 @@ impl FromRequestParts<AppState> for AgentId {
         parts: &mut Parts,
         state: &AppState,
     ) -> Result<Self, Self::Rejection> {
+        if let Some(auth) = parts.extensions.get::<AuthContext>() {
+            if let Some(agent_id) = auth.agent_id() {
+                reject_mismatched_agent_header(&parts.headers, agent_id)?;
+                return Ok(AgentId(agent_id.to_string()));
+            }
+        }
+
+        if let Some(token) = bearer_token(&parts.headers) {
+            let auth = resolve_bearer_token(Some(state), token).await?;
+            if let Some(agent_id) = auth.agent_id() {
+                reject_mismatched_agent_header(&parts.headers, agent_id)?;
+                parts.extensions.insert(auth.clone());
+                return Ok(AgentId(agent_id.to_string()));
+            }
+        }
+
         let value = parts
             .headers
             .get(HEADER_AGENT_ID)
@@ -130,5 +215,77 @@ impl FromRequestParts<AppState> for AgentId {
         }
 
         Ok(AgentId(value.to_string()))
+    }
+}
+
+fn request_has_valid_sim_key(headers: &axum::http::HeaderMap) -> AppResult<bool> {
+    let provided = headers
+        .get(HEADER_SIM_KEY)
+        .and_then(|v| v.to_str().ok())
+        .map(|s| s.trim())
+        .unwrap_or("");
+
+    if provided.is_empty() {
+        return Ok(false);
+    }
+
+    let expected = std::env::var("SIM_API_KEY")?;
+    Ok(provided == expected)
+}
+
+fn bearer_token(headers: &axum::http::HeaderMap) -> Option<&str> {
+    let value = headers
+        .get(AUTHORIZATION)
+        .and_then(|v| v.to_str().ok())?
+        .trim();
+
+    value
+        .strip_prefix("Bearer ")
+        .map(str::trim)
+        .filter(|token| !token.is_empty())
+}
+
+async fn resolve_bearer_token(state: Option<&AppState>, token: &str) -> AppResult<AuthContext> {
+    if !token.starts_with(AGENT_TOKEN_PREFIX) {
+        return Err(AppError::Unauthorized);
+    }
+
+    let state = state.ok_or(AppError::Unauthorized)?;
+    let token_hash = hash_agent_token(token);
+
+    let agent_id = sqlx::query_scalar::<_, String>(
+        r#"
+        UPDATE agent_tokens
+        SET last_used_at = NOW()
+        WHERE token_hash = $1
+          AND revoked_at IS NULL
+        RETURNING agent_id
+        "#,
+    )
+    .bind(token_hash)
+    .fetch_optional(state.pool())
+    .await?
+    .ok_or(AppError::Unauthorized)?;
+
+    Ok(AuthContext::agent(agent_id))
+}
+
+fn reject_mismatched_agent_header(
+    headers: &axum::http::HeaderMap,
+    resolved_agent_id: &str,
+) -> AppResult<()> {
+    let Some(header_agent_id) = headers
+        .get(HEADER_AGENT_ID)
+        .and_then(|v| v.to_str().ok())
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    else {
+        return Ok(());
+    };
+
+    if header_agent_id == resolved_agent_id {
+        Ok(())
+    } else {
+        Err(AppError::Forbidden)
     }
 }

--- a/world-api/src/main.rs
+++ b/world-api/src/main.rs
@@ -44,6 +44,7 @@ use routes::locations::{get_location_by_id, get_nearby_locations, list_locations
 use routes::objects::{list_objects_by_location, update_object_state};
 use routes::pathfind::get_path;
 use routes::sleep::{start_sleep, wake_up};
+use routes::tokens::{create_agent_token, list_agent_tokens, revoke_agent_token};
 use routes::world::get_world_time;
 use state::AppState;
 use ws_events::ws_events;
@@ -89,6 +90,9 @@ async fn main() -> AppResult<()> {
         .route("/agents", get(list_agents))
         .route("/agents/health", get(agent_health_check))
         .route("/agents/move", patch(move_agent_with_header))
+        .route("/admin/agents/:id/tokens", get(list_agent_tokens))
+        .route("/admin/agents/:id/tokens", post(create_agent_token))
+        .route("/admin/agent-tokens/:id", delete(revoke_agent_token))
         .route("/jobs", get(list_jobs))
         .route("/jobs/:id", get(get_job_by_id))
         .route("/jobs/:id/agents", get(list_job_agents))
@@ -129,7 +133,10 @@ async fn main() -> AppResult<()> {
                 .allow_methods(Any)
                 .allow_headers(Any),
         )
-        .layer(axum::middleware::from_fn(require_sim_key))
+        .layer(axum::middleware::from_fn_with_state(
+            state.clone(),
+            require_sim_key,
+        ))
         .with_state(state);
 
     let addr = SocketAddr::from(([0, 0, 0, 0], port));

--- a/world-api/src/routes/agents.rs
+++ b/world-api/src/routes/agents.rs
@@ -5,7 +5,7 @@ use axum::{
 use chrono::Utc;
 use serde::{Deserialize, Serialize};
 
-use crate::auth::AgentId;
+use crate::auth::{AgentId, AuthContext};
 use crate::error::AppError;
 use crate::error::AppResult;
 use crate::models::agent::Agent;
@@ -95,9 +95,12 @@ pub async fn get_agent_by_id(
 
 pub async fn update_agent_location(
     State(state): State<AppState>,
+    auth: AuthContext,
     Path(agent_id): Path<String>,
     Json(payload): Json<UpdateAgentLocationRequest>,
 ) -> AppResult<Json<ApiResponse<Agent>>> {
+    auth.ensure_agent(&agent_id)?;
+
     let updated_agent =
         perform_agent_location_update(&state, &agent_id, &payload.location_id).await?;
 
@@ -286,9 +289,12 @@ async fn perform_agent_location_update(
 
 pub async fn update_agent_activity(
     State(state): State<AppState>,
+    auth: AuthContext,
     Path(agent_id): Path<String>,
     Json(payload): Json<UpdateAgentActivityRequest>,
 ) -> AppResult<Json<Agent>> {
+    auth.ensure_agent(&agent_id)?;
+
     let mut tx = state.pool().begin().await?;
 
     let updated_agent = sqlx::query_as::<_, Agent>(
@@ -336,8 +342,11 @@ pub async fn update_agent_activity(
 
 pub async fn clear_agent_activity(
     State(state): State<AppState>,
+    auth: AuthContext,
     Path(agent_id): Path<String>,
 ) -> AppResult<Json<Agent>> {
+    auth.ensure_agent(&agent_id)?;
+
     let mut tx = state.pool().begin().await?;
 
     let updated_agent = sqlx::query_as::<_, Agent>(

--- a/world-api/src/routes/events.rs
+++ b/world-api/src/routes/events.rs
@@ -4,6 +4,7 @@ use axum::{
 };
 use chrono::Utc;
 
+use crate::auth::SimKey;
 use crate::error::{AppError, AppResult};
 use crate::models::event::{CreateEventRequest, EventsQuery, SimEvent};
 use crate::state::AppState;
@@ -39,6 +40,7 @@ pub async fn list_events(
 
 pub async fn create_event(
     State(state): State<AppState>,
+    _sim_key: SimKey,
     Json(payload): Json<CreateEventRequest>,
 ) -> AppResult<Json<SimEvent>> {
     if payload.r#type.trim().is_empty() {

--- a/world-api/src/routes/intentions.rs
+++ b/world-api/src/routes/intentions.rs
@@ -5,6 +5,7 @@ use axum::{
 use chrono::Utc;
 use uuid::Uuid;
 
+use crate::auth::AuthContext;
 use crate::error::{AppError, AppResult};
 use crate::models::common::ApiResponse;
 use crate::models::intention::{
@@ -85,9 +86,12 @@ pub async fn get_current_agent_intention(
 
 pub async fn create_agent_intention(
     State(state): State<AppState>,
+    auth: AuthContext,
     Path(agent_id): Path<String>,
     Json(payload): Json<CreateAgentIntentionRequest>,
 ) -> AppResult<Json<ApiResponse<AgentIntention>>> {
+    auth.ensure_agent(&agent_id)?;
+
     let summary = required_text(payload.summary, "summary")?;
     let reason = required_text(payload.reason, "reason")?;
     let expected_action = optional_text(payload.expected_action);
@@ -157,9 +161,12 @@ pub async fn create_agent_intention(
 
 pub async fn update_agent_intention(
     State(state): State<AppState>,
+    auth: AuthContext,
     Path(path): Path<AgentIntentionPath>,
     Json(payload): Json<UpdateAgentIntentionRequest>,
 ) -> AppResult<Json<ApiResponse<AgentIntention>>> {
+    auth.ensure_agent(&path.id)?;
+
     let mut tx = state.pool().begin().await?;
     let current_location_id = ensure_agent_exists_for_update(&mut tx, &path.id).await?;
 

--- a/world-api/src/routes/inventory.rs
+++ b/world-api/src/routes/inventory.rs
@@ -5,7 +5,7 @@ use axum::{
 use chrono::Utc;
 use serde::Deserialize;
 
-use crate::auth::AgentId;
+use crate::auth::{AgentId, AuthContext};
 use crate::error::{AppError, AppResult};
 use crate::models::agent::Agent;
 use crate::models::common::{ApiResponse, NotificationMode, NotificationPayload};
@@ -64,9 +64,12 @@ pub async fn get_agent_inventory(
 
 pub async fn add_item_to_agent_inventory(
     State(state): State<AppState>,
+    auth: AuthContext,
     Path(agent_id): Path<String>,
     Json(payload): Json<AddInventoryItemRequest>,
 ) -> AppResult<Json<InventoryItem>> {
+    auth.ensure_agent(&agent_id)?;
+
     let mut tx = state.pool().begin().await?;
 
     let agent_location = sqlx::query_scalar::<_, String>(
@@ -131,9 +134,12 @@ pub async fn add_item_to_agent_inventory(
 
 pub async fn remove_item_from_agent_inventory(
     State(state): State<AppState>,
+    auth: AuthContext,
     Path(agent_id): Path<String>,
     Json(payload): Json<RemoveInventoryItemRequest>,
 ) -> AppResult<Json<InventoryItem>> {
+    auth.ensure_agent(&agent_id)?;
+
     let mut tx = state.pool().begin().await?;
 
     let agent_location = sqlx::query_scalar::<_, String>(
@@ -196,9 +202,12 @@ pub async fn remove_item_from_agent_inventory(
 
 pub async fn transfer_item_between_agents(
     State(state): State<AppState>,
+    auth: AuthContext,
     Path(from_agent_id): Path<String>,
     Json(payload): Json<TransferItemRequest>,
 ) -> AppResult<Json<serde_json::Value>> {
+    auth.ensure_agent(&from_agent_id)?;
+
     if from_agent_id == payload.to_agent_id {
         return Err(AppError::BadRequest(
             "source and destination agents must be different".to_string(),
@@ -322,7 +331,9 @@ pub async fn use_item(
     Json(payload): Json<UseItemRequest>,
 ) -> AppResult<Json<ApiResponse<Agent>>> {
     if payload.quantity <= 0 {
-        return Err(AppError::BadRequest("quantity must be positive".to_string()));
+        return Err(AppError::BadRequest(
+            "quantity must be positive".to_string(),
+        ));
     }
 
     let mut tx = state.pool().begin().await?;
@@ -344,9 +355,10 @@ pub async fn use_item(
 
     let use_quantity = payload.quantity as i16;
     if item.quantity < use_quantity {
-        return Err(AppError::BadRequest(
-            format!("not enough quantity (have {}, requested {})", item.quantity, use_quantity)
-        ));
+        return Err(AppError::BadRequest(format!(
+            "not enough quantity (have {}, requested {})",
+            item.quantity, use_quantity
+        )));
     }
 
     // Apply vital adjustments if this is a consumable
@@ -427,7 +439,10 @@ pub async fn use_item(
     .bind("item.used")
     .bind(&agent_id)
     .bind(&agent.current_location_id)
-    .bind(format!("Agent {} used {} x{}", agent_id, item.name, use_quantity))
+    .bind(format!(
+        "Agent {} used {} x{}",
+        agent_id, item.name, use_quantity
+    ))
     .bind(
         serde_json::json!({
             "item_id": item.id,

--- a/world-api/src/routes/jobs.rs
+++ b/world-api/src/routes/jobs.rs
@@ -5,6 +5,7 @@ use axum::{
 use chrono::Utc;
 use serde::Deserialize;
 
+use crate::auth::AuthContext;
 use crate::error::{AppError, AppResult};
 use crate::models::common::ApiResponse;
 use crate::models::job::{AssignedJob, Job, JobAgent, UpsertAgentJobRequest};
@@ -114,9 +115,12 @@ pub async fn list_agent_jobs(
 
 pub async fn upsert_agent_job(
     State(state): State<AppState>,
+    auth: AuthContext,
     Path(path): Path<AgentJobPath>,
     Json(payload): Json<UpsertAgentJobRequest>,
 ) -> AppResult<Json<ApiResponse<AssignedJob>>> {
+    auth.ensure_agent(&path.id)?;
+
     let mut tx = state.pool().begin().await?;
     let current_location_id = ensure_agent_exists_for_update(&mut tx, &path.id).await?;
     ensure_job_exists_for_update(&mut tx, &path.job_id).await?;
@@ -199,8 +203,11 @@ pub async fn upsert_agent_job(
 
 pub async fn remove_agent_job(
     State(state): State<AppState>,
+    auth: AuthContext,
     Path(path): Path<AgentJobPath>,
 ) -> AppResult<Json<ApiResponse<AssignedJob>>> {
+    auth.ensure_agent(&path.id)?;
+
     let mut tx = state.pool().begin().await?;
     let current_location_id = ensure_agent_exists_for_update(&mut tx, &path.id).await?;
 

--- a/world-api/src/routes/mod.rs
+++ b/world-api/src/routes/mod.rs
@@ -9,4 +9,5 @@ pub mod locations;
 pub mod objects;
 pub mod pathfind;
 pub mod sleep;
+pub mod tokens;
 pub mod world;

--- a/world-api/src/routes/objects.rs
+++ b/world-api/src/routes/objects.rs
@@ -1,10 +1,10 @@
 use axum::{
     Json,
     extract::{Path, State},
-    http::HeaderMap,
 };
 use chrono::Utc;
 
+use crate::auth::AgentId;
 use crate::error::{AppError, AppResult};
 use crate::models::object::{UpdateWorldObjectRequest, WorldObject};
 use crate::state::AppState;
@@ -45,24 +45,10 @@ pub async fn list_objects_by_location(
 
 pub async fn update_object_state(
     State(state): State<AppState>,
-    headers: HeaderMap,
+    AgentId(actor_id): AgentId,
     Path(object_id): Path<String>,
     Json(payload): Json<UpdateWorldObjectRequest>,
 ) -> AppResult<Json<WorldObject>> {
-    let actor_id = headers
-        .get("x-agent-id")
-        .ok_or_else(|| AppError::BadRequest("missing x-agent-id header".to_string()))?
-        .to_str()
-        .map_err(|_| AppError::BadRequest("invalid x-agent-id header".to_string()))?
-        .trim()
-        .to_string();
-
-    if actor_id.is_empty() {
-        return Err(AppError::BadRequest(
-            "x-agent-id header cannot be empty".to_string(),
-        ));
-    }
-
     let mut tx = state.pool().begin().await?;
 
     let updated_object = sqlx::query_as::<_, WorldObject>(

--- a/world-api/src/routes/tokens.rs
+++ b/world-api/src/routes/tokens.rs
@@ -1,0 +1,149 @@
+use axum::{
+    Json,
+    extract::{Path, State},
+};
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::auth::{SimKey, hash_agent_token};
+use crate::error::{AppError, AppResult};
+use crate::models::common::ApiResponse;
+use crate::state::AppState;
+
+const AGENT_TOKEN_PREFIX: &str = "lcity_agent_";
+
+#[derive(Debug, Deserialize)]
+pub struct CreateAgentTokenRequest {
+    pub label: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct CreateAgentTokenResponse {
+    pub id: String,
+    pub agent_id: String,
+    pub token: String,
+    pub label: Option<String>,
+    pub created_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Serialize, sqlx::FromRow)]
+pub struct AgentTokenSummary {
+    pub id: String,
+    pub agent_id: String,
+    pub label: Option<String>,
+    pub created_at: DateTime<Utc>,
+    pub last_used_at: Option<DateTime<Utc>>,
+    pub revoked_at: Option<DateTime<Utc>>,
+}
+
+pub async fn create_agent_token(
+    State(state): State<AppState>,
+    _sim_key: SimKey,
+    Path(agent_id): Path<String>,
+    Json(payload): Json<CreateAgentTokenRequest>,
+) -> AppResult<Json<ApiResponse<CreateAgentTokenResponse>>> {
+    ensure_agent_exists(&state, &agent_id).await?;
+
+    let token = generate_agent_token();
+    let token_hash = hash_agent_token(&token);
+    let label = payload.label.and_then(|value| {
+        let trimmed = value.trim().to_string();
+        if trimmed.is_empty() {
+            None
+        } else {
+            Some(trimmed)
+        }
+    });
+
+    let created = sqlx::query_as::<_, AgentTokenSummary>(
+        r#"
+        INSERT INTO agent_tokens (id, agent_id, token_hash, label, created_at)
+        VALUES ($1, $2, $3, $4, NOW())
+        RETURNING id, agent_id, label, created_at, last_used_at, revoked_at
+        "#,
+    )
+    .bind(format!("token_{}", Uuid::new_v4()))
+    .bind(&agent_id)
+    .bind(token_hash)
+    .bind(label)
+    .fetch_one(state.pool())
+    .await?;
+
+    Ok(Json(ApiResponse::from(CreateAgentTokenResponse {
+        id: created.id,
+        agent_id: created.agent_id,
+        token,
+        label: created.label,
+        created_at: created.created_at,
+    })))
+}
+
+pub async fn list_agent_tokens(
+    State(state): State<AppState>,
+    _sim_key: SimKey,
+    Path(agent_id): Path<String>,
+) -> AppResult<Json<ApiResponse<Vec<AgentTokenSummary>>>> {
+    ensure_agent_exists(&state, &agent_id).await?;
+
+    let tokens = sqlx::query_as::<_, AgentTokenSummary>(
+        r#"
+        SELECT id, agent_id, label, created_at, last_used_at, revoked_at
+        FROM agent_tokens
+        WHERE agent_id = $1
+        ORDER BY created_at DESC
+        "#,
+    )
+    .bind(agent_id)
+    .fetch_all(state.pool())
+    .await?;
+
+    Ok(Json(ApiResponse::from(tokens)))
+}
+
+pub async fn revoke_agent_token(
+    State(state): State<AppState>,
+    _sim_key: SimKey,
+    Path(token_id): Path<String>,
+) -> AppResult<Json<ApiResponse<AgentTokenSummary>>> {
+    let token = sqlx::query_as::<_, AgentTokenSummary>(
+        r#"
+        UPDATE agent_tokens
+        SET revoked_at = COALESCE(revoked_at, NOW())
+        WHERE id = $1
+        RETURNING id, agent_id, label, created_at, last_used_at, revoked_at
+        "#,
+    )
+    .bind(token_id)
+    .fetch_optional(state.pool())
+    .await?
+    .ok_or(AppError::NotFound)?;
+
+    Ok(Json(ApiResponse::from(token)))
+}
+
+fn generate_agent_token() -> String {
+    format!(
+        "{}{}{}",
+        AGENT_TOKEN_PREFIX,
+        Uuid::new_v4().simple(),
+        Uuid::new_v4().simple()
+    )
+}
+
+async fn ensure_agent_exists(state: &AppState, agent_id: &str) -> AppResult<()> {
+    let exists = sqlx::query_scalar::<_, bool>(
+        r#"
+        SELECT EXISTS(SELECT 1 FROM agents WHERE id = $1)
+        "#,
+    )
+    .bind(agent_id)
+    .fetch_one(state.pool())
+    .await?;
+
+    if exists {
+        Ok(())
+    } else {
+        Err(AppError::NotFound)
+    }
+}


### PR DESCRIPTION
## Summary
- Add `agent_tokens` storage with hashed bearer tokens, one-time raw token creation, token listing, and revocation admin routes.
- Allow mutating World API requests to authenticate with `Authorization: Bearer lcity_agent_...`, resolving the actor server-side instead of trusting `x-agent-id`.
- Update high-value agent mutation routes, `lcity`, and the living-in-letta-city skill wrapper to support hosted-world token auth while keeping `SIM_API_KEY` for local/admin workflows.

Refs #50.

## Validation
- `cargo test` in `world-api`.
- `node --check lcity/src/cli.mjs`.
- `node --check skills/living-in-letta-city/scripts/lcity-agent.mjs`.
- `npm ci && npm run build` in `frontend`.
- Bundled Docker smoke on port 3007: create token, `whoami`, bearer-auth move, mismatched `x-agent-id` returns 403, path spoof returns 403, bearer-created raw event returns 401, revoke token, revoked token returns 401.

"A public city still needs door keys."

Written by Cameron ◯ Letta Code