### PR TITLE
fix: repair citizen harness runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,10 +187,15 @@ Quick start:
 
 ```powershell
 npm --prefix .\lcity install
+$env:LCITY_API_BASE="https://app-production-8df5.up.railway.app/api"
+$env:LCITY_CITY_AGENT_ID="eddy_lin"
+$env:LCITY_AGENT_TOKEN="lcity_agent_..."
 $env:LETTA_API_KEY="<your-letta-api-key>"
 $env:LETTA_AGENT_ID="agent-..."
-node .\lcity\bin\lcity.mjs citizen run --mode env
+node .\lcity\bin\lcity.mjs citizen run --mode env --plain
 ```
+
+For the bundled Railway deployment, the HTTP API is exposed under `/api`, while websocket traffic is exposed under `/ws/citizen`. The citizen harness derives that websocket URL automatically. If you need to override it, set `LCITY_CITIZEN_WS_URL` or pass `--ws-url`.
 
 There is also now a profile-driven local mode:
 

--- a/docs/guides/public-railway-instance.md
+++ b/docs/guides/public-railway-instance.md
@@ -145,6 +145,25 @@ node .\lcity\bin\lcity.mjs complete_intention --outcome "Reached Hobbs Cafe and 
 
 Public board posts should be useful to the town, not debug spam.
 
+## Running the citizen harness against Railway
+
+Use this when a real Letta agent should wake from city events and act with the server-provided citizen tool bundle.
+
+```powershell
+npm --prefix .\lcity install
+
+$env:LCITY_API_BASE = "https://app-production-8df5.up.railway.app/api"
+$env:LCITY_CITY_AGENT_ID = "eddy_lin"
+$env:LCITY_AGENT_TOKEN = "lcity_agent_..."
+$env:LETTA_API_KEY = "<your-letta-api-key>"
+$env:LETTA_AGENT_ID = "agent-..."
+
+node .\lcity\bin\lcity.mjs citizen config validate --mode env --plain
+node .\lcity\bin\lcity.mjs citizen run --mode env --plain
+```
+
+The bundled public app proxies HTTP API routes through `/api` and websocket routes through `/ws/citizen`. `lcity citizen run` derives that websocket URL automatically from `LCITY_API_BASE`; if you need to override it, set `LCITY_CITIZEN_WS_URL` or pass `--ws-url`.
+
 ## Using the Letta Code skill
 
 The repo includes `skills/living-in-letta-city/`. For the hosted world, prefer an explicit bearer token flow:

--- a/lcity/README.md
+++ b/lcity/README.md
@@ -79,6 +79,21 @@ Citizen runtime implementation notes:
 - fetches a **server-owned tool manifest** from the World API
 - registers only the currently relevant local world tools for that wake/context
 
+Minimal env-mode run:
+
+```powershell
+$env:LCITY_API_BASE="https://app-production-8df5.up.railway.app/api"
+$env:LCITY_CITY_AGENT_ID="eddy_lin"
+$env:LCITY_AGENT_TOKEN="lcity_agent_..."
+$env:LETTA_API_KEY="<your-letta-api-key>"
+$env:LETTA_AGENT_ID="agent-..."
+
+node .\lcity\bin\lcity.mjs citizen config validate --mode env --plain
+node .\lcity\bin\lcity.mjs citizen run --mode env --plain
+```
+
+If the derived websocket URL does not match the hosted world, override it with `LCITY_CITIZEN_WS_URL` or `--ws-url`. Bundled Railway deployments expose HTTP routes through `/api` and websocket routes through `/ws/citizen`.
+
 Canonical citizen config now lives under:
 
 ```text
@@ -258,5 +273,4 @@ lcity lettabot_notify --message "Broadcast" --agent-id sam_moore
 ```
 
 Under the hood, the CLI posts to the local daemon (`/notify`), which converts the request into a normalized interrupt and dispatches it through `interruptAgent(...)`. The current transport adapter then uses your `LETTABOT_API_KEY` + base URL to call `/v1/chat/completions`.
-
 

--- a/lcity/src/citizen/config.mjs
+++ b/lcity/src/citizen/config.mjs
@@ -19,7 +19,7 @@ export function usage() {
     "lcity citizen profile use --name <profile>",
     "lcity citizen doctor [--profile <name>]",
     "lcity citizen tools preview [--profile <name>]",
-    "Key flags: --sim-key, --tool-manifest-strategy, --tool-auth-mode",
+    "Key flags: --api-base, --ws-url, --city-agent-id, --agent-token, --sim-key, --tool-manifest-strategy, --tool-auth-mode",
   ];
 }
 

--- a/lcity/src/citizen/config/resolve.mjs
+++ b/lcity/src/citizen/config/resolve.mjs
@@ -24,9 +24,10 @@ function normalizeApiBase(apiBase) {
 
 function wsUrlFromApiBase(apiBase) {
   const trimmed = normalizeApiBase(apiBase);
-  if (trimmed.startsWith("https://")) return `wss://${trimmed.slice("https://".length)}/ws/citizen`;
-  if (trimmed.startsWith("http://")) return `ws://${trimmed.slice("http://".length)}/ws/citizen`;
-  return `${trimmed}/ws/citizen`;
+  const publicOrigin = trimmed.endsWith("/api") ? trimmed.slice(0, -4) : trimmed;
+  if (publicOrigin.startsWith("https://")) return `wss://${publicOrigin.slice("https://".length)}/ws/citizen`;
+  if (publicOrigin.startsWith("http://")) return `ws://${publicOrigin.slice("http://".length)}/ws/citizen`;
+  return `${publicOrigin}/ws/citizen`;
 }
 
 function parsePositiveInteger(value, fallback) {
@@ -228,6 +229,22 @@ export function resolveRuntimeConfig({ flags = {}, cwd = process.cwd() } = {}) {
     cwd,
   });
 
+  const wsUrl = resolvedString({
+    flagValue: flags.wsUrl,
+    envName: "LCITY_CITIZEN_WS_URL",
+    profileValue: profileData.world?.ws_url,
+    filePath: "",
+    defaultValue: "",
+    label: "--ws-url",
+    cwd,
+  });
+  const resolvedWsUrl = wsUrl.present
+    ? wsUrl
+    : createResolvedValue({
+      value: wsUrlFromApiBase(apiBase.value),
+      source: `derived:${apiBase.source}`,
+    });
+
   const worldAuthProfile = profileData.world?.auth || {};
   const worldToolAuthProfile = profileData.world?.tool_auth || {};
 
@@ -333,7 +350,7 @@ export function resolveRuntimeConfig({ flags = {}, cwd = process.cwd() } = {}) {
     },
     world: {
       api_base: apiBase,
-      ws_url: createResolvedValue({ value: wsUrlFromApiBase(apiBase.value), source: `derived:${apiBase.source}` }),
+      ws_url: resolvedWsUrl,
       tool_manifest_strategy: resolvedString({
         flagValue: flags.toolManifestStrategy,
         envName: "LCITY_CITIZEN_TOOL_MANIFEST_STRATEGY",

--- a/lcity/src/citizen/config/resolve.test.mjs
+++ b/lcity/src/citizen/config/resolve.test.mjs
@@ -43,13 +43,13 @@ test("derives Railway bundled citizen websocket URL from /api base", () => {
     }, () => resolveRuntimeConfig({
       cwd,
       flags: {
-        apiBase: "https://app-production-8df5.up.railway.app/api",
+        apiBase: "https://hosted-world.example/api",
       },
     }));
 
     assert.equal(
       resolved.world.ws_url.value,
-      "wss://app-production-8df5.up.railway.app/ws/citizen",
+      "wss://hosted-world.example/ws/citizen",
     );
   } finally {
     rmSync(cwd, { recursive: true, force: true });
@@ -65,7 +65,7 @@ test("supports explicit citizen websocket URL override", () => {
     }, () => resolveRuntimeConfig({
       cwd,
       flags: {
-        apiBase: "https://app-production-8df5.up.railway.app/api",
+        apiBase: "https://hosted-world.example/api",
       },
     }));
 

--- a/lcity/src/citizen/config/resolve.test.mjs
+++ b/lcity/src/citizen/config/resolve.test.mjs
@@ -1,0 +1,77 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import { resolveRuntimeConfig } from "../config.mjs";
+
+function withEnv(vars, fn) {
+  const previous = new Map();
+  for (const key of Object.keys(vars)) {
+    previous.set(key, process.env[key]);
+    if (vars[key] == null) {
+      delete process.env[key];
+    } else {
+      process.env[key] = vars[key];
+    }
+  }
+
+  try {
+    return fn();
+  } finally {
+    for (const [key, value] of previous.entries()) {
+      if (value == null) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+  }
+}
+
+function tempCwd() {
+  return mkdtempSync(path.join(tmpdir(), "lcity-citizen-config-"));
+}
+
+test("derives Railway bundled citizen websocket URL from /api base", () => {
+  const cwd = tempCwd();
+  try {
+    const resolved = withEnv({
+      LCITY_API_BASE: null,
+      LCITY_CITIZEN_WS_URL: null,
+    }, () => resolveRuntimeConfig({
+      cwd,
+      flags: {
+        apiBase: "https://app-production-8df5.up.railway.app/api",
+      },
+    }));
+
+    assert.equal(
+      resolved.world.ws_url.value,
+      "wss://app-production-8df5.up.railway.app/ws/citizen",
+    );
+  } finally {
+    rmSync(cwd, { recursive: true, force: true });
+  }
+});
+
+test("supports explicit citizen websocket URL override", () => {
+  const cwd = tempCwd();
+  try {
+    const resolved = withEnv({
+      LCITY_API_BASE: null,
+      LCITY_CITIZEN_WS_URL: "wss://example.test/custom/citizen",
+    }, () => resolveRuntimeConfig({
+      cwd,
+      flags: {
+        apiBase: "https://app-production-8df5.up.railway.app/api",
+      },
+    }));
+
+    assert.equal(resolved.world.ws_url.value, "wss://example.test/custom/citizen");
+    assert.equal(resolved.world.ws_url.source, "env:LCITY_CITIZEN_WS_URL");
+  } finally {
+    rmSync(cwd, { recursive: true, force: true });
+  }
+});

--- a/world-api/src/routes/citizens.rs
+++ b/world-api/src/routes/citizens.rs
@@ -703,8 +703,8 @@ pub async fn enqueue_citizen_wake_tx(
         VALUES (
             $1, $2, $3, $4, $5, $6, $7::jsonb,
             $8::jsonb, $9, $10::jsonb, $11::jsonb, $12,
-            $13, $14, $15, $16,
-            $17
+            $13, $14, $15,
+            $16
         )
         "#,
     )


### PR DESCRIPTION
## Summary
- Fix citizen websocket URL resolution for bundled Railway `/api` deployments and add an explicit `--ws-url` / `LCITY_CITIZEN_WS_URL` override.
- Fix admin test wake creation by correcting the `citizen_wakes` insert placeholder count.
- Document the hosted citizen harness env-mode flow and add config regression coverage.

"Wake the town, but use the right door."

Written by Cameron ◯ Letta Code