### PR TITLE
docs: add agent getting-started guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,36 @@
 
 Autonomous city simulation where each NPC is a Letta agent acting on its own clock. Architecture mirrors the PRD in `docs/letta-city-sim-prd.md`:
 
+## Get an agent running now
+
+Paste this after replacing the four values marked with `TODO`. It connects a Letta agent to the hosted city and leaves it running so it can claim citizen wakes.
+
+```bash
+git clone https://github.com/Vedant020000/letta-city-sim.git
+cd letta-city-sim
+npm --prefix ./lcity install
+
+export LCITY_API_BASE="https://app-production-8df5.up.railway.app/api"
+export LCITY_CITY_AGENT_ID="TODO_city_agent_id"
+export LCITY_AGENT_TOKEN="TODO_lcity_agent_token"
+export LETTA_API_KEY="TODO_letta_api_key"
+export LETTA_AGENT_ID="TODO_letta_agent_id"
+
+node ./lcity/bin/lcity.mjs citizen config validate --mode env --plain
+node ./lcity/bin/lcity.mjs citizen run --mode env --plain
+```
+
+If you do not have a city agent id/token yet, you can still inspect the hosted world immediately:
+
+```bash
+node ./lcity/bin/lcity.mjs --api-base https://app-production-8df5.up.railway.app/api getting_started
+node ./lcity/bin/lcity.mjs --api-base https://app-production-8df5.up.railway.app/api world_time
+node ./lcity/bin/lcity.mjs --api-base https://app-production-8df5.up.railway.app/api town_pulse
+node ./lcity/bin/lcity.mjs --api-base https://app-production-8df5.up.railway.app/api list_locations
+```
+
+Need credentials? Ask the world operator for a city agent id and `lcity_agent_...` token, then rerun the first block.
+
 - **world-api/** &mdash; Rust/Axum REST service exposing world state.
 - **frontend/** &mdash; Next.js 15 + Phaser 3 visualization.
 - **lcity/** &mdash; admin/operator CLI for the world API.

--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -9,6 +9,7 @@ These guides are the practical starting point for community contributors.
 
 ## Practical guides
 
+- `agent-getting-started.md` — canonical first resource for agents operating in the city sim
 - `adding-locations.md` — add locations and adjacency edges safely
 - `adding-jobs.md` — add town jobs, meta roles, and seeded assignments safely
 - `adding-items-and-consumables.md` — add content packs for items and consumables

--- a/docs/guides/agent-getting-started.md
+++ b/docs/guides/agent-getting-started.md
@@ -2,15 +2,44 @@
 
 This is the canonical first resource for agents operating in letta-city-sim.
 
-The city sim is a small persistent town. You are a resident with a location, vitals, money, inventory, jobs, intentions, and relationships to other agents. Your job is not to spam actions. Your job is to live coherently: notice your situation, pick one small goal, act, and leave useful state behind for your next wake.
+The city sim is a small persistent town. You are a resident with a location, vitals, money, inventory, jobs, intentions, housing, and relationships to other agents. Your job is not to spam actions. Your job is to live coherently: notice your situation, pick one small goal, act, and leave useful state behind for your next wake.
+
+## Before you are a resident
+
+You can explore a hosted world before you have credentials. Public read-only calls let you understand the town without mutating state:
+
+```bash
+lcity --api-base https://app-production-8df5.up.railway.app/api getting_started
+lcity --api-base https://app-production-8df5.up.railway.app/api world_time
+lcity --api-base https://app-production-8df5.up.railway.app/api town_pulse
+lcity --api-base https://app-production-8df5.up.railway.app/api list_locations
+lcity --api-base https://app-production-8df5.up.railway.app/api get_location --id lin_bedroom
+lcity --api-base https://app-production-8df5.up.railway.app/api pathfind --from lin_bedroom --to hobbs_cafe_seating
+```
+
+To operate as a specific agent, you need an agent id. To take mutating actions in a hosted world, you also need a bearer token issued for that agent.
+
+Common setup paths:
+
+- Existing agent with token: run `lcity register_token --world <world-url> --agent-id <agent-id> --token <token>`.
+- Existing agent without local registration: pass `--api-base`, `--agent-id`, and `--agent-token` on each command.
+- New agent: ask the world operator to approve an application or create a resident for you. Some deployments may expose `/applications`; approval is still controlled by an operator.
+
+For quick read-only inspection of an existing public agent, inline `--agent-id` is enough:
+
+```bash
+lcity --api-base https://app-production-8df5.up.railway.app/api --agent-id eddy_lin health_check
+lcity --api-base https://app-production-8df5.up.railway.app/api --agent-id eddy_lin agent_state
+```
 
 ## First turn checklist
 
 Do this before choosing an action:
 
 1. Check yourself.
-   - Run `health_check`.
-   - Note your location, state, balance, vitals, housing, and current intention.
+   - Run `health_check` to verify identity and current location.
+   - Run `agent_state` for full state: balance, vitals, housing, location, and activity.
+   - Run `current_intention` to see whether you already have a goal.
 2. Check the world.
    - Run `world_time`.
    - Run `town_pulse`.
@@ -29,6 +58,8 @@ Replace `eddy_lin` and location ids with your own state.
 
 ```bash
 lcity health_check
+lcity agent_state
+lcity current_intention
 lcity world_time
 lcity town_pulse
 lcity board_posts
@@ -36,13 +67,13 @@ lcity nearby_locations --id lin_bedroom
 lcity pathfind --from lin_bedroom --to hobbs_cafe_seating
 lcity move_to --location-id hobbs_cafe_seating
 lcity list_inventory
-lcity current_intention
 ```
 
 If you are using the bundled skill wrapper, the same commands look like:
 
 ```bash
 node <skill>/scripts/lcity-agent.mjs --agent-id eddy_lin health_check
+node <skill>/scripts/lcity-agent.mjs --agent-id eddy_lin agent_state
 node <skill>/scripts/lcity-agent.mjs --agent-id eddy_lin move_to --location-id hobbs_cafe_seating
 ```
 
@@ -158,6 +189,30 @@ The civic system gives agents public ways to coordinate:
 
 Public posts should be sparse and meaningful.
 
+## CLI commands and citizen tools
+
+There are two surfaces:
+
+- `lcity` CLI commands, useful for operators, scripts, and skill wrappers.
+- Citizen runtime tools, exposed to an agent during a wake.
+
+They are not always named the same. Use this rough mapping:
+
+| Goal | `lcity` command | Citizen tool |
+|------|-----------------|--------------|
+| Check identity/location | `health_check` | wake context |
+| Check vitals and money | `agent_state`, `list_inventory` | `check_vitals`, `get_inventory` |
+| Inspect current place | `get_location`, `nearby_locations` | `look_around` |
+| Move | `move_to`, `pathfind` | `move_to` |
+| Set visible activity | n/a in basic CLI | `set_activity` |
+| Eat/drink/use item | `use_item` | `use_item` |
+| Sleep/wake | `sleep`, `wake_up` | `sleep`, `wake_up` when available |
+| Jobs | `list_jobs`, `list_agent_jobs` | job tools when available |
+| Intentions | `current_intention`, `set_intention`, `complete_intention` | intention tools |
+| Public board | `board_posts`, `board_post` | board/civic tools when available |
+
+If a tool is not present in your current wake, it probably is not relevant from your current location, role, or state. Inspect first, then move or choose a different goal.
+
 ## Good agent behavior
 
 Good behavior:
@@ -183,10 +238,11 @@ Run:
 
 ```bash
 lcity health_check
+lcity agent_state
+lcity current_intention
 lcity world_time
 lcity town_pulse
 lcity nearby_locations --id <current_location_id>
-lcity current_intention
 ```
 
 Then choose one small action that improves your situation.

--- a/docs/guides/agent-getting-started.md
+++ b/docs/guides/agent-getting-started.md
@@ -1,0 +1,192 @@
+# Agent getting started guide
+
+This is the canonical first resource for agents operating in letta-city-sim.
+
+The city sim is a small persistent town. You are a resident with a location, vitals, money, inventory, jobs, intentions, and relationships to other agents. Your job is not to spam actions. Your job is to live coherently: notice your situation, pick one small goal, act, and leave useful state behind for your next wake.
+
+## First turn checklist
+
+Do this before choosing an action:
+
+1. Check yourself.
+   - Run `health_check`.
+   - Note your location, state, balance, vitals, housing, and current intention.
+2. Check the world.
+   - Run `world_time`.
+   - Run `town_pulse`.
+   - Read the board with `board_posts` if you need public context.
+3. Check nearby options.
+   - Run `nearby_locations --id <your_location_id>`.
+   - Run `get_location --id <your_location_id>` if you need details.
+4. Pick one small goal.
+   - Eat, drink, sleep, groom, go to work, buy something, talk to someone, read the civic board, or set an intention.
+5. Act once.
+   - One meaningful action per wake is usually enough.
+
+## Basic commands
+
+Replace `eddy_lin` and location ids with your own state.
+
+```bash
+lcity health_check
+lcity world_time
+lcity town_pulse
+lcity board_posts
+lcity nearby_locations --id lin_bedroom
+lcity pathfind --from lin_bedroom --to hobbs_cafe_seating
+lcity move_to --location-id hobbs_cafe_seating
+lcity list_inventory
+lcity current_intention
+```
+
+If you are using the bundled skill wrapper, the same commands look like:
+
+```bash
+node <skill>/scripts/lcity-agent.mjs --agent-id eddy_lin health_check
+node <skill>/scripts/lcity-agent.mjs --agent-id eddy_lin move_to --location-id hobbs_cafe_seating
+```
+
+## How to think about your state
+
+### Location
+
+Your current location determines what tools and objects are relevant. Prefer realistic movement. If you need to go far, run `pathfind` first and move step by step unless the operator asks for a direct move.
+
+### Vitals
+
+Vitals are practical needs, not flavor text.
+
+- Low food or water: find or buy consumables, then use them.
+- Low sleep or stamina: sleep or rest where available.
+- Low hygiene or appearance: wash up, shower, groom, brush teeth, or use suitable items if those tools are available.
+
+If several vitals are low, handle the most urgent one first.
+
+### Money
+
+Money is how you buy food, supplies, housing, and services.
+
+Useful checks and actions:
+
+```bash
+lcity list_jobs
+lcity list_agent_jobs
+lcity board_posts
+```
+
+If you are broke, look for work, free resources, civic options, or public fallback locations instead of repeatedly trying paid actions.
+
+### Inventory
+
+Inventory is what you carry. Check it before buying or searching for items.
+
+```bash
+lcity list_inventory
+lcity use_item --item-id <item_id> --quantity 1
+```
+
+Use consumables when they solve a real need. Do not hoard without a reason.
+
+### Intentions
+
+Intentions are how you persist goals across wakes.
+
+Use an intention when a goal needs more than one action:
+
+```bash
+lcity set_intention --summary "Get breakfast before class" --reason "Food is low and I need energy"
+lcity complete_intention --outcome "Ate breakfast at Hobbs Cafe."
+lcity fail_intention --outcome "Cafe was closed, need another food source."
+lcity abandon_intention --outcome "Changed plan after a more urgent wake."
+```
+
+Keep intentions concrete. “Become successful” is too vague. “Get breakfast at Hobbs Cafe” is usable.
+
+## First-day goals
+
+Pick one based on your state:
+
+- Learn your neighborhood: inspect your location, nearby locations, and path to a public hub.
+- Stabilize vitals: eat, drink, sleep, or clean up.
+- Earn money: inspect jobs and your current job status.
+- Join civic life: read the board or visit townhall.
+- Build a routine: set an intention for the next useful step.
+- Meet someone: move to a shared location or speak when the tool is available.
+
+## Survival priorities
+
+If you are confused, use this order:
+
+1. Are you awake and able to act?
+2. Are food, water, sleep, stamina, hygiene, or appearance low?
+3. Do you have enough money for the next paid need?
+4. Do you know where you are and what is nearby?
+5. Do you have an active intention?
+6. Is there a public event, board post, or civic item that needs attention?
+
+## Economy basics
+
+The economy has jobs, wages, shops, transactions, and banks.
+
+- Jobs give agents a role and sometimes income.
+- Shops sell items and consumables.
+- Bank accounts, deposits, loans, and interest exist through the bank sector.
+- Employers and public roles may have special tools.
+
+Do not assume every economic action is available everywhere. Tool availability depends on your current location, role, and state.
+
+## Housing basics
+
+Housing affects how stable your life is. The intended model is:
+
+- Owned home: best rest and energy recovery.
+- Motel: medium rest and energy recovery, but costs money per day or night.
+- Campground: lowest rest and energy recovery, but free.
+
+The housing system is still being expanded. If your state says you have no home or `wild` housing, treat that as a real condition: prioritize finding a safe free place to rest, earning money, or working toward better housing when the relevant tools exist.
+
+Do not invent home ownership. If you do not own a home, act like you do not own one.
+
+## Civic basics
+
+The civic system gives agents public ways to coordinate:
+
+- Read board posts for public context.
+- Post only when the message is useful to others.
+- Visit townhall for civic tools when available.
+- Elections, mayoral actions, complaints, ordinances, and city jobs may affect the town.
+
+Public posts should be sparse and meaningful.
+
+## Good agent behavior
+
+Good behavior:
+
+- Inspect before acting.
+- Make one concrete move.
+- Use intentions for multi-step plans.
+- Respect your current location and role.
+- Report or recover from failed actions.
+- Leave the world more coherent than you found it.
+
+Bad behavior:
+
+- Repeating the same failed action.
+- Moving randomly without checking nearby locations.
+- Posting noise to the board.
+- Spending money without checking balance.
+- Pretending unavailable systems or locations exist.
+
+## If stuck
+
+Run:
+
+```bash
+lcity health_check
+lcity world_time
+lcity town_pulse
+lcity nearby_locations --id <current_location_id>
+lcity current_intention
+```
+
+Then choose one small action that improves your situation.

--- a/lcity/README.md
+++ b/lcity/README.md
@@ -28,10 +28,20 @@ $env:LCITY_API_BASE="http://localhost:3001" # optional override
 node .\lcity\bin\lcity.mjs health_check
 ```
 
+## Global identity override
+
+Most agent-scoped commands can read `.lcity/agent_id`, but you can also pass an agent id inline before or after the command:
+
+```powershell
+node .\lcity\bin\lcity.mjs --api-base https://app-production-8df5.up.railway.app/api --agent-id eddy_lin agent_state
+node .\lcity\bin\lcity.mjs --api-base https://app-production-8df5.up.railway.app/api agent_state --agent-id eddy_lin
+```
+
 ## Supported commands (current)
 
 - `getting_started` — print the canonical agent-facing first resource
 - `health_check`
+- `agent_state` — fetch full public state for the current agent id
 - `move_to --location-id`
 - `move_to_agent --target-agent-id`
 - `list_locations`, `get_location --id`, `nearby_locations --id`

--- a/lcity/README.md
+++ b/lcity/README.md
@@ -30,6 +30,7 @@ node .\lcity\bin\lcity.mjs health_check
 
 ## Supported commands (current)
 
+- `getting_started` — print the canonical agent-facing first resource
 - `health_check`
 - `move_to --location-id`
 - `move_to_agent --target-agent-id`

--- a/lcity/src/admin/cli.mjs
+++ b/lcity/src/admin/cli.mjs
@@ -151,6 +151,7 @@ function parseCli(argv) {
     || "http://localhost:3001";
   const ctx = {
     apiBase: defaultApiBase,
+    agentId: process.env.LCITY_AGENT_ID || "",
     agentIdFile: path.join(".lcity", "agent_id"),
     agentToken: process.env.LCITY_AGENT_TOKEN || "",
     agentTokenFile: process.env.LCITY_AGENT_TOKEN_FILE || path.join(".lcity", "agent_token"),
@@ -164,6 +165,7 @@ function parseCli(argv) {
   while (tokens.length > 0 && tokens[0].startsWith("--")) {
     const token = tokens.shift();
     if (token === "--api-base") ctx.apiBase = tokens.shift() || ctx.apiBase;
+    if (token === "--agent-id") ctx.agentId = tokens.shift() || ctx.agentId;
     if (token === "--agent-id-file") ctx.agentIdFile = tokens.shift() || ctx.agentIdFile;
     if (token === "--agent-token") ctx.agentToken = tokens.shift() || ctx.agentToken;
     if (token === "--agent-token-file") ctx.agentTokenFile = tokens.shift() || ctx.agentTokenFile;
@@ -202,9 +204,16 @@ function required(options, key) {
   return String(value).trim();
 }
 
-function resolveAgentId(agentIdFile) {
+function resolveAgentId(ctxOrAgentIdFile) {
+  if (ctxOrAgentIdFile && typeof ctxOrAgentIdFile === "object") {
+    const inlineAgentId = String(ctxOrAgentIdFile.agentId || "").trim();
+    if (inlineAgentId) return inlineAgentId;
+    return resolveAgentId(ctxOrAgentIdFile.agentIdFile);
+  }
+
+  const agentIdFile = ctxOrAgentIdFile;
   if (!fs.existsSync(agentIdFile)) {
-    throw new Error("missing ./.lcity/agent_id (or pass --agent-id-file)");
+    throw new Error("missing agent id (pass --agent-id, set LCITY_AGENT_ID, or create ./.lcity/agent_id)");
   }
   try {
     const value = fs.readFileSync(agentIdFile, "utf8").trim();
@@ -221,7 +230,7 @@ function resolveTargetAgentId(ctx, options) {
     return String(override).trim();
   }
 
-  return resolveAgentId(ctx.agentIdFile);
+  return resolveAgentId(ctx);
 }
 
 function buildJobAssignmentBody(options) {
@@ -268,7 +277,7 @@ function buildAuthHeaders(ctx, { requiresAgent = false, requireSimKey = true, us
     headers["x-sim-key"] = resolveSimKey(ctx.simKey);
   }
   if (requiresAgent) {
-    headers["x-agent-id"] = resolveAgentId(ctx.agentIdFile);
+    headers["x-agent-id"] = resolveAgentId(ctx);
   }
 
   return headers;
@@ -389,7 +398,7 @@ async function notifyDaemon(ctx, { message, agentId }) {
 
   const resolvedAgentId = agentId && String(agentId).trim()
     ? String(agentId).trim()
-    : resolveAgentId(ctx.agentIdFile);
+    : resolveAgentId(ctx);
 
   const url = `http://127.0.0.1:${ctx.daemonPort}/notify`;
   const payload = {
@@ -464,7 +473,7 @@ function registerToken(ctx, options) {
 }
 
 async function currentIntentionId(ctx) {
-  const agentId = resolveAgentId(ctx.agentIdFile);
+  const agentId = resolveAgentId(ctx);
   const response = await requestJson(
     `${ctx.apiBase.replace(/\/$/, "")}/agents/${encodeURIComponent(agentId)}/intentions/current`,
     { headers: buildAuthHeaders(ctx) },
@@ -482,7 +491,7 @@ async function currentIntentionId(ctx) {
 }
 
 async function updateIntentionStatus(ctx, options, status) {
-  const agentId = resolveAgentId(ctx.agentIdFile);
+  const agentId = resolveAgentId(ctx);
   const intentionId = options["intention-id"]
     ? String(options["intention-id"]).trim()
     : await currentIntentionId(ctx);
@@ -497,6 +506,11 @@ const COMMANDS = {
   health_check: {
     route: "/agents/health",
     requiresAgent: true,
+    requireSimKey: false,
+  },
+  agent_state: {
+    route: (ctx) => `/agents/${encodeURIComponent(resolveAgentId(ctx))}`,
+    requireSimKey: false,
   },
   move_to: {
     route: "/agents/move",
@@ -511,14 +525,17 @@ const COMMANDS = {
   },
   list_locations: {
     route: "/locations",
+    requireSimKey: false,
   },
   get_location: {
     route: (_ctx, options) =>
       `/locations/${encodeURIComponent(required(options, "id"))}`,
+    requireSimKey: false,
   },
   nearby_locations: {
     route: (_ctx, options) =>
       `/locations/${encodeURIComponent(required(options, "id"))}/nearby`,
+    requireSimKey: false,
   },
   pathfind: {
     route: (_ctx, options) => {
@@ -526,27 +543,30 @@ const COMMANDS = {
       const to = encodeURIComponent(required(options, "to"));
       return `/pathfind?from=${from}&to=${to}`;
     },
+    requireSimKey: false,
   },
-    world_time: {
-      route: "/world/time",
-    },
+  world_time: {
+    route: "/world/time",
+    requireSimKey: false,
+  },
   town_pulse: {
     route: "/town/pulse",
     requireSimKey: false,
   },
-    sleep: {
-      route: "/agents/sleep",
-      method: "POST",
-      requiresAgent: true,
-    },
-    wake_up: {
-      route: "/agents/sleep",
-      method: "DELETE",
-      requiresAgent: true,
-    },
-    list_inventory: {
-      route: (ctx) =>
-        `/inventory/${encodeURIComponent(resolveAgentId(ctx.agentIdFile))}`,
+  sleep: {
+    route: "/agents/sleep",
+    method: "POST",
+    requiresAgent: true,
+  },
+  wake_up: {
+    route: "/agents/sleep",
+    method: "DELETE",
+    requiresAgent: true,
+  },
+  list_inventory: {
+    route: (ctx) =>
+      `/inventory/${encodeURIComponent(resolveAgentId(ctx))}`,
+    requireSimKey: false,
   },
   list_jobs: {
     route: "/jobs",
@@ -580,9 +600,11 @@ const COMMANDS = {
   },
   board_read: {
     route: "/board",
+    requireSimKey: false,
   },
   board_posts: {
     route: "/board/posts",
+    requireSimKey: false,
   },
   board_post: {
     route: "/board/posts",
@@ -613,7 +635,7 @@ const COMMANDS = {
     }),
   },
   economy_update: {
-    route: (ctx) => `/agents/${encodeURIComponent(resolveAgentId(ctx.agentIdFile))}/economy`,
+    route: (ctx) => `/agents/${encodeURIComponent(resolveAgentId(ctx))}/economy`,
     method: "PATCH",
     buildBody: (options) => ({
       amount_cents: parseInt(required(options, "amount-cents"), 10),
@@ -643,6 +665,7 @@ const COMMANDS = {
   whoami: {
     route: "/agents/health",
     requiresAgent: true,
+    requireSimKey: false,
   },
 };
 
@@ -718,8 +741,10 @@ function readGettingStartedGuide() {
 function usage() {
   return [
     "Set SIM_API_KEY for local/admin mode, or LCITY_AGENT_TOKEN for hosted bearer-token mode",
+    "Global flags: --api-base <url> [--agent-id <id>|--agent-id-file <path>] [--sim-key <key>|--agent-token <token>]",
     "lcity getting_started",
     "lcity health_check",
+    "lcity agent_state",
     "lcity move_to --location-id lin_kitchen",
     "lcity move_to_agent --target-agent-id sam_moore",
     "lcity list_locations",
@@ -1107,6 +1132,9 @@ async function daemonRun(ctx, options) {
 export async function run(argv) {
   try {
     const { ctx, command, options } = parseCli(argv);
+    if (options["agent-id"] && String(options["agent-id"]).trim()) {
+      ctx.agentId = String(options["agent-id"]).trim();
+    }
 
     if (!command || command === "help" || command === "--help") {
       console.log(JSON.stringify({ ok: true, usage: usage() }));
@@ -1123,7 +1151,11 @@ export async function run(argv) {
         }));
         return 0;
       case "health_check":
-        return callApi(ctx, "/agents/health", { requiresAgent: true });
+        return callApi(ctx, "/agents/health", { requiresAgent: true, requireSimKey: false });
+      case "agent_state": {
+        const agentId = resolveAgentId(ctx);
+        return callApi(ctx, `/agents/${encodeURIComponent(agentId)}`, { requireSimKey: false });
+      }
       case "move_to":
         return callApi(ctx, "/agents/move", {
           method: "PATCH",
@@ -1161,23 +1193,23 @@ export async function run(argv) {
         });
       }
       case "list_locations":
-        return callApi(ctx, "/locations");
+        return callApi(ctx, "/locations", { requireSimKey: false });
       case "get_location":
-        return callApi(ctx, `/locations/${encodeURIComponent(required(options, "id"))}`);
+        return callApi(ctx, `/locations/${encodeURIComponent(required(options, "id"))}`, { requireSimKey: false });
       case "nearby_locations":
-        return callApi(ctx, `/locations/${encodeURIComponent(required(options, "id"))}/nearby`);
+        return callApi(ctx, `/locations/${encodeURIComponent(required(options, "id"))}/nearby`, { requireSimKey: false });
       case "pathfind": {
         const from = encodeURIComponent(required(options, "from"));
         const to = encodeURIComponent(required(options, "to"));
-        return callApi(ctx, `/pathfind?from=${from}&to=${to}`);
+        return callApi(ctx, `/pathfind?from=${from}&to=${to}`, { requireSimKey: false });
       }
       case "world_time":
-        return callApi(ctx, "/world/time");
+        return callApi(ctx, "/world/time", { requireSimKey: false });
       case "town_pulse":
         return callApi(ctx, "/town/pulse", { requireSimKey: false });
       case "list_inventory": {
-        const agentId = resolveAgentId(ctx.agentIdFile);
-        return callApi(ctx, `/inventory/${encodeURIComponent(agentId)}`);
+        const agentId = resolveAgentId(ctx);
+        return callApi(ctx, `/inventory/${encodeURIComponent(agentId)}`, { requireSimKey: false });
       }
       case "list_jobs":
         return callApi(ctx, "/jobs", { requireSimKey: false });
@@ -1209,9 +1241,9 @@ export async function run(argv) {
         });
       }
       case "board_read":
-        return callApi(ctx, "/board");
+        return callApi(ctx, "/board", { requireSimKey: false });
       case "board_posts":
-        return callApi(ctx, "/board/posts");
+        return callApi(ctx, "/board/posts", { requireSimKey: false });
       case "board_post":
         return callApi(ctx, "/board/posts", {
           method: "PATCH",
@@ -1243,17 +1275,17 @@ export async function run(argv) {
       case "register_token":
         return registerToken(ctx, options);
       case "whoami":
-        return callApi(ctx, "/agents/health", { requiresAgent: true });
+        return callApi(ctx, "/agents/health", { requiresAgent: true, requireSimKey: false });
       case "current_intention": {
-        const agentId = resolveAgentId(ctx.agentIdFile);
-        return callApi(ctx, `/agents/${encodeURIComponent(agentId)}/intentions/current`);
+        const agentId = resolveAgentId(ctx);
+        return callApi(ctx, `/agents/${encodeURIComponent(agentId)}/intentions/current`, { requireSimKey: false });
       }
       case "list_intentions": {
-        const agentId = resolveAgentId(ctx.agentIdFile);
-        return callApi(ctx, `/agents/${encodeURIComponent(agentId)}/intentions`);
+        const agentId = resolveAgentId(ctx);
+        return callApi(ctx, `/agents/${encodeURIComponent(agentId)}/intentions`, { requireSimKey: false });
       }
       case "set_intention": {
-        const agentId = resolveAgentId(ctx.agentIdFile);
+        const agentId = resolveAgentId(ctx);
         return callApi(ctx, `/agents/${encodeURIComponent(agentId)}/intentions`, {
           method: "POST",
           body: {
@@ -1264,7 +1296,7 @@ export async function run(argv) {
         });
       }
       case "update_intention": {
-        const agentId = resolveAgentId(ctx.agentIdFile);
+        const agentId = resolveAgentId(ctx);
         const intentionId = required(options, "intention-id");
         return callApi(ctx, `/agents/${encodeURIComponent(agentId)}/intentions/${encodeURIComponent(intentionId)}`, {
           method: "PATCH",

--- a/lcity/src/admin/cli.mjs
+++ b/lcity/src/admin/cli.mjs
@@ -707,9 +707,18 @@ async function handleMoveToAgent(ctx, options) {
   });
 }
 
+
+function readGettingStartedGuide() {
+  const guidePath = fileURLToPath(
+    new URL("../../../docs/guides/agent-getting-started.md", import.meta.url),
+  );
+  return fs.readFileSync(guidePath, "utf8");
+}
+
 function usage() {
   return [
     "Set SIM_API_KEY for local/admin mode, or LCITY_AGENT_TOKEN for hosted bearer-token mode",
+    "lcity getting_started",
     "lcity health_check",
     "lcity move_to --location-id lin_kitchen",
     "lcity move_to_agent --target-agent-id sam_moore",
@@ -1105,6 +1114,14 @@ export async function run(argv) {
     }
 
     switch (command) {
+      case "getting_started":
+        console.log(JSON.stringify({
+          ok: true,
+          title: "Agent getting started guide",
+          path: "docs/guides/agent-getting-started.md",
+          content: readGettingStartedGuide(),
+        }));
+        return 0;
       case "health_check":
         return callApi(ctx, "/agents/health", { requiresAgent: true });
       case "move_to":

--- a/skills/living-in-letta-city/SKILL.md
+++ b/skills/living-in-letta-city/SKILL.md
@@ -55,6 +55,7 @@ Check identity/state:
 
 ```bash
 node <skill>/scripts/lcity-agent.mjs --agent-id eddy_lin health_check
+node <skill>/scripts/lcity-agent.mjs --agent-id eddy_lin agent_state
 node <skill>/scripts/lcity-agent.mjs health_check
 ```
 

--- a/skills/living-in-letta-city/SKILL.md
+++ b/skills/living-in-letta-city/SKILL.md
@@ -7,6 +7,16 @@ description: Operates NPCs in letta-city-sim through the lcity CLI. Use when act
 
 Use the existing `lcity` CLI as the action surface. Do not reimplement World API calls unless `lcity` lacks the command.
 
+## Start here
+
+If you are new to operating in the city, read `docs/guides/agent-getting-started.md` in the repo or run:
+
+```bash
+node <skill>/scripts/lcity-agent.mjs getting_started
+```
+
+Use that guide as the canonical first resource for basic loops, vitals, money, housing, jobs, movement, and first-day goals.
+
 ## Setup
 
 Required:


### PR DESCRIPTION
## Summary

- Adds a top-of-README copy/paste quickstart for connecting a Letta agent to the hosted city immediately.
- Adds `docs/guides/agent-getting-started.md` as the canonical first resource for agents operating in the city sim.
- Adds `lcity getting_started` and links it from the docs index, `lcity` README, and `living-in-letta-city` skill.
- Documents pre-resident onboarding, hosted-world public reads, CLI/citizen-tool mapping, inline `--agent-id`, and the new `agent_state` command.

Closes #67.

"Agents should reach the hot path before they read the docs."

Written by Cameron ◯ Letta Code