### PR TITLE
feat: add housing-aware sleep options

### DIFF
--- a/scripts/db-bootstrap.sh
+++ b/scripts/db-bootstrap.sh
@@ -64,11 +64,17 @@ apply_seed_file() {
 
 apply_seeds() {
   apply_seed_file "$SEED_DIR/locations.sql"
+  if [ -f "$SEED_DIR/dorms.sql" ]; then
+    apply_seed_file "$SEED_DIR/dorms.sql"
+  fi
   apply_seed_file "$SEED_DIR/adjacency.sql"
   apply_seed_file "$SEED_DIR/objects.sql"
   apply_seed_file "$SEED_DIR/agents.sql"
   apply_seed_file "$SEED_DIR/jobs.sql"
   apply_seed_file "$SEED_DIR/agent_jobs.sql"
+  if [ -f "$SEED_DIR/location_roles.sql" ]; then
+    apply_seed_file "$SEED_DIR/location_roles.sql"
+  fi
   if [ -f "$SEED_DIR/shops.sql" ]; then
     apply_seed_file "$SEED_DIR/shops.sql"
   fi

--- a/scripts/seed.ps1
+++ b/scripts/seed.ps1
@@ -7,11 +7,13 @@ $ErrorActionPreference = "Stop"
 
 $seedFiles = @(
     "seed/locations.sql",
+    "seed/dorms.sql",
     "seed/adjacency.sql",
     "seed/objects.sql",
     "seed/agents.sql",
     "seed/jobs.sql",
-    "seed/agent_jobs.sql"
+    "seed/agent_jobs.sql",
+    "seed/location_roles.sql"
 )
 
 foreach ($file in $seedFiles) {
@@ -23,4 +25,3 @@ foreach ($file in $seedFiles) {
 }
 
 Write-Host "Seeding complete."
-

--- a/seed/adjacency.sql
+++ b/seed/adjacency.sql
@@ -70,6 +70,17 @@ VALUES
   ('smallville_bank_office', 'smallville_bank_vault', 6),
   ('smallville_bank_vault', 'smallville_bank_office', 6),
   ('smallville_bank_lobby', 'harvey_oak_entrance', 80),
-  ('harvey_oak_entrance', 'smallville_bank_lobby', 80)
+  ('harvey_oak_entrance', 'smallville_bank_lobby', 80),
+  -- Housing fallback and temporary lodging
+  ('ville_park_east', 'smallville_campground', 80),
+  ('smallville_campground', 'ville_park_east', 80),
+  ('miller_community_garden', 'smallville_campground', 60),
+  ('smallville_campground', 'miller_community_garden', 60),
+  ('harvey_oak_entrance', 'smallville_motel_lobby', 45),
+  ('smallville_motel_lobby', 'harvey_oak_entrance', 45),
+  ('notice_board', 'smallville_motel_lobby', 70),
+  ('smallville_motel_lobby', 'notice_board', 70),
+  ('smallville_motel_lobby', 'smallville_motel_room', 8),
+  ('smallville_motel_room', 'smallville_motel_lobby', 8)
 ON CONFLICT (from_id, to_id) DO UPDATE
 SET travel_secs = EXCLUDED.travel_secs;

--- a/seed/locations.sql
+++ b/seed/locations.sql
@@ -24,7 +24,10 @@ VALUES
   ('townhall_voting_booth', 'Voting Booth', 'A small booth where citizens cast their ballots for mayor.', 608, 304, 'civic'),
   ('smallville_bank_lobby', 'Smallville Bank Lobby', 'A quiet bank lobby with teller windows, a posted rate board, and polished stone floors.', 416, 352, 'workplace'),
   ('smallville_bank_office', 'Smallville Bank Office', 'A private office where the banker reviews balances, rates, and loan requests.', 416, 320, 'workplace'),
-  ('smallville_bank_vault', 'Smallville Bank Vault', 'A secured vault room holding the town bank reserves and ledgers.', 384, 320, 'workplace')
+  ('smallville_bank_vault', 'Smallville Bank Vault', 'A secured vault room holding the town bank reserves and ledgers.', 384, 320, 'workplace'),
+  ('smallville_campground', 'Smallville Campground', 'A free public campground with simple tent sites near the park. It is safe, but not especially restful.', 800, 512, 'public'),
+  ('smallville_motel_lobby', 'Smallville Motel Lobby', 'A modest motel lobby with a front desk, room keys, and posted nightly rates.', 448, 512, 'business'),
+  ('smallville_motel_room', 'Smallville Motel Room', 'A clean temporary room with a made bed and thin curtains. It costs money, but sleeps better than the campground.', 480, 512, 'business')
 ON CONFLICT (id) DO UPDATE
 SET name = EXCLUDED.name,
     description = EXCLUDED.description,

--- a/seed/objects.sql
+++ b/seed/objects.sql
@@ -15,7 +15,9 @@ VALUES
   ('delivery_crate_hobbs', 'Delivery Crate', 'hobbs_cafe_kitchen', '{"delivery_pending": false}', ARRAY['receive']),
   ('bank_teller_counter', 'Bank Teller Counter', 'smallville_bank_lobby', '{"open": true}', ARRAY['deposit', 'withdraw', 'loan']),
   ('bank_rate_board', 'Bank Rate Board', 'smallville_bank_lobby', '{"posted": true}', ARRAY['read']),
-  ('bank_vault_door', 'Bank Vault Door', 'smallville_bank_vault', '{"locked": true}', ARRAY['inspect'])
+  ('bank_vault_door', 'Bank Vault Door', 'smallville_bank_vault', '{"locked": true}', ARRAY['inspect']),
+  ('tent_site_campground', 'Campground Tent Site', 'smallville_campground', '{"occupied_by": null, "shared_sleep_site": true, "housing_tier": "campground", "sleep_recovery_per_min": 1.0, "stamina_recovery_per_min": 0.4, "nightly_price_cents": 0}', ARRAY['sleep', 'rest']),
+  ('bed_smallville_motel_room', 'Smallville Motel Bed', 'smallville_motel_room', '{"occupied_by": null, "housing_tier": "motel", "sleep_recovery_per_min": 2.0, "stamina_recovery_per_min": 0.7, "nightly_price_cents": 2500}', ARRAY['sleep'])
 ON CONFLICT (id) DO UPDATE
 SET name = EXCLUDED.name,
     location_id = EXCLUDED.location_id,

--- a/world-api/src/error.rs
+++ b/world-api/src/error.rs
@@ -34,22 +34,37 @@ pub enum AppError {
 #[derive(Serialize)]
 struct ErrorResponse<'a> {
     error: &'a str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    detail: Option<&'a str>,
 }
 
 impl IntoResponse for AppError {
     fn into_response(self) -> axum::response::Response {
-        let (status, message) = match &self {
-            AppError::Database(_) => (StatusCode::INTERNAL_SERVER_ERROR, "database error"),
-            AppError::Config(_) => (StatusCode::INTERNAL_SERVER_ERROR, "configuration error"),
-            AppError::Io(_) => (StatusCode::INTERNAL_SERVER_ERROR, "io error"),
-            AppError::NotFound => (StatusCode::NOT_FOUND, "not found"),
-            AppError::BadRequest(_) => (StatusCode::BAD_REQUEST, "bad request"),
-            AppError::Unauthorized => (StatusCode::UNAUTHORIZED, "unauthorized"),
-            AppError::Forbidden => (StatusCode::FORBIDDEN, "forbidden"),
-            AppError::Unexpected(_) => (StatusCode::INTERNAL_SERVER_ERROR, "unexpected error"),
+        let (status, message, detail) = match &self {
+            AppError::Database(_) => (StatusCode::INTERNAL_SERVER_ERROR, "database error", None),
+            AppError::Config(_) => (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "configuration error",
+                None,
+            ),
+            AppError::Io(_) => (StatusCode::INTERNAL_SERVER_ERROR, "io error", None),
+            AppError::NotFound => (StatusCode::NOT_FOUND, "not found", None),
+            AppError::BadRequest(detail) => (
+                StatusCode::BAD_REQUEST,
+                "bad request",
+                Some(detail.as_str()),
+            ),
+            AppError::Unauthorized => (StatusCode::UNAUTHORIZED, "unauthorized", None),
+            AppError::Forbidden => (StatusCode::FORBIDDEN, "forbidden", None),
+            AppError::Unexpected(_) => {
+                (StatusCode::INTERNAL_SERVER_ERROR, "unexpected error", None)
+            }
         };
 
-        let body = Json(ErrorResponse { error: message });
+        let body = Json(ErrorResponse {
+            error: message,
+            detail,
+        });
         (status, body).into_response()
     }
 }

--- a/world-api/src/routes/actions.rs
+++ b/world-api/src/routes/actions.rs
@@ -3982,7 +3982,7 @@ fn tool_look_around() -> WorldToolDefinition {
 fn tool_sleep() -> WorldToolDefinition {
     WorldToolDefinition {
         name: "sleep".to_string(),
-        description: "Go to sleep if the current location has a valid bed.".to_string(),
+        description: "Go to sleep if the current location has a valid bed. Recovery depends on housing tier; motel beds cost money, campground sleep is free but weak.".to_string(),
         endpoint: "/actions/sleep".to_string(),
         method: "POST".to_string(),
         parameters: json!({
@@ -3996,7 +3996,7 @@ fn tool_sleep() -> WorldToolDefinition {
 fn tool_wake_up() -> WorldToolDefinition {
     WorldToolDefinition {
         name: "wake_up".to_string(),
-        description: "Wake up from sleep. Your sleep_level will have recovered while you were sleeping.".to_string(),
+        description: "Wake up from sleep. The response explains sleep and stamina recovery from the housing tier you used.".to_string(),
         endpoint: "/actions/wake_up".to_string(),
         method: "POST".to_string(),
         parameters: json!({

--- a/world-api/src/routes/applications.rs
+++ b/world-api/src/routes/applications.rs
@@ -151,8 +151,8 @@ pub async fn approve_application(
 
         dorm_id
     } else {
-        // No dorms available — agent lives in the wild
-        "ville_park_east".to_string()
+        // No dorms available — agent starts at the free campground fallback.
+        "smallville_campground".to_string()
     };
 
     sqlx::query(

--- a/world-api/src/routes/sleep.rs
+++ b/world-api/src/routes/sleep.rs
@@ -8,6 +8,7 @@ use crate::models::agent::Agent;
 use crate::models::common::{ApiResponse, NotificationMode, NotificationPayload};
 use crate::models::object::WorldObject;
 use crate::routes::citizens::enqueue_citizen_wake_tx;
+use crate::routes::vitals::SleepRecoveryPlan;
 use crate::state::AppState;
 use crate::ws_events::WorldEventEnvelope;
 
@@ -23,6 +24,24 @@ fn occupied_by(state: &Value) -> Option<String> {
         .get("occupied_by")
         .and_then(|value| value.as_str())
         .map(|value| value.to_string())
+}
+
+fn is_shared_sleep_site(state: &Value) -> bool {
+    state
+        .get("shared_sleep_site")
+        .and_then(|value| value.as_bool())
+        .unwrap_or(false)
+}
+
+fn format_cents(cents: i64) -> String {
+    format!("${:.2}", cents as f64 / 100.0)
+}
+
+fn recovery_reason(plan: &SleepRecoveryPlan) -> String {
+    format!(
+        "{} recovery: +{:.1} sleep/min, +{:.1} stamina/min",
+        plan.label, plan.sleep_recovery_per_min, plan.stamina_recovery_per_min
+    )
 }
 
 async fn location_targets(
@@ -108,7 +127,10 @@ pub async fn start_sleep(
         }
     };
 
-    if let Some(current_occupant) = occupied_by(&bed.state)
+    let shared_sleep_site = is_shared_sleep_site(&bed.state);
+
+    if !shared_sleep_site
+        && let Some(current_occupant) = occupied_by(&bed.state)
         && current_occupant != agent.id
     {
         return Err(AppError::BadRequest(format!(
@@ -117,8 +139,76 @@ pub async fn start_sleep(
         )));
     }
 
+    let sleep_plan = crate::routes::vitals::sleep_recovery_plan_for_bed_tx(
+        &mut tx,
+        &agent.id,
+        bed.location_id.as_deref(),
+        &bed.state,
+    )
+    .await?;
+
+    let mut sleep_cost_cents = 0_i64;
+    let mut post_payment_balance = agent.balance_cents;
+    if sleep_plan.cost_cents > 0 {
+        if agent.balance_cents < sleep_plan.cost_cents {
+            return Err(AppError::BadRequest(format!(
+                "insufficient balance for {} (have {}, need {}); try the campground fallback",
+                sleep_plan.label,
+                format_cents(agent.balance_cents),
+                format_cents(sleep_plan.cost_cents)
+            )));
+        }
+
+        post_payment_balance = sqlx::query_scalar::<_, i64>(
+            r#"
+            UPDATE agents
+            SET balance_cents = balance_cents - $1,
+                last_expense_cents = $1,
+                last_expense_reason = $2,
+                last_expense_at = NOW(),
+                updated_at = NOW()
+            WHERE id = $3 AND balance_cents >= $1
+            RETURNING balance_cents
+            "#,
+        )
+        .bind(sleep_plan.cost_cents)
+        .bind(format!("{} lodging", sleep_plan.label))
+        .bind(&agent.id)
+        .fetch_optional(&mut *tx)
+        .await?
+        .ok_or_else(|| {
+            AppError::BadRequest(format!(
+                "insufficient balance for {} (need {})",
+                sleep_plan.label,
+                format_cents(sleep_plan.cost_cents)
+            ))
+        })?;
+
+        sqlx::query(
+            r#"
+            INSERT INTO economy_transactions (
+                from_agent_id, to_agent_id, amount_cents, reason,
+                transaction_type, status, location_id, resolved_at
+            )
+            VALUES ($1, NULL, $2, $3, 'payment', 'completed', $4, NOW())
+            "#,
+        )
+        .bind(&agent.id)
+        .bind(sleep_plan.cost_cents)
+        .bind(format!("{} lodging", sleep_plan.label))
+        .bind(&agent.current_location_id)
+        .execute(&mut *tx)
+        .await?;
+
+        sleep_cost_cents = sleep_plan.cost_cents;
+    }
+
     let mut bed_state = normalize_bed_state(&bed.state);
-    bed_state.insert("occupied_by".to_string(), Value::String(agent.id.clone()));
+    if shared_sleep_site {
+        bed_state.insert("last_used_by".to_string(), Value::String(agent.id.clone()));
+    } else {
+        bed_state.insert("occupied_by".to_string(), Value::String(agent.id.clone()));
+    }
 
     sqlx::query(
         r#"
@@ -162,6 +252,13 @@ pub async fn start_sleep(
             "agent_id": agent.id,
             "bed_id": bed.id,
             "location_id": agent.current_location_id,
+            "housing_tier": &sleep_plan.tier,
+            "recovery_reason": recovery_reason(&sleep_plan),
+            "sleep_recovery_per_min": sleep_plan.sleep_recovery_per_min,
+            "stamina_recovery_per_min": sleep_plan.stamina_recovery_per_min,
+            "cost_cents": sleep_cost_cents,
+            "balance_cents": post_payment_balance,
+            "shared_sleep_site": shared_sleep_site,
         })
         .to_string(),
     )
@@ -172,7 +269,10 @@ pub async fn start_sleep(
     let targets = location_targets(&mut tx, &agent.current_location_id, &agent.id).await?;
     let mut citizen_signal_targets = Vec::new();
 
-    for target_agent_id in targets.iter().filter(|target| target.as_str() != agent.id.as_str()) {
+    for target_agent_id in targets
+        .iter()
+        .filter(|target| target.as_str() != agent.id.as_str())
+    {
         let enqueued = enqueue_citizen_wake_tx(
             &mut tx,
             target_agent_id,
@@ -184,6 +284,10 @@ pub async fn start_sleep(
                     "agent_id": agent.id,
                     "bed_id": bed.id,
                     "location_id": agent.current_location_id,
+                    "housing_tier": &sleep_plan.tier,
+                    "recovery_reason": recovery_reason(&sleep_plan),
+                    "cost_cents": sleep_cost_cents,
+                    "shared_sleep_site": shared_sleep_site,
                 }
             }),
             format!("{} just went to sleep.", agent.name),
@@ -194,6 +298,10 @@ pub async fn start_sleep(
                 "bed_id": bed.id,
                 "bed_name": bed.name,
                 "location_id": agent.current_location_id,
+                "housing_tier": &sleep_plan.tier,
+                "recovery_reason": recovery_reason(&sleep_plan),
+                "cost_cents": sleep_cost_cents,
+                "shared_sleep_site": shared_sleep_site,
             }),
             json!([]),
             true,
@@ -230,13 +338,28 @@ pub async fn start_sleep(
             "agent_id": updated_agent.id,
             "bed_id": bed.id,
             "location_id": updated_agent.current_location_id,
+            "housing_tier": &sleep_plan.tier,
+            "recovery_reason": recovery_reason(&sleep_plan),
+            "cost_cents": sleep_cost_cents,
+            "shared_sleep_site": shared_sleep_site,
         }),
     ));
+
+    let payment_prefix = if sleep_cost_cents > 0 {
+        format!("Paid {} and ", format_cents(sleep_cost_cents))
+    } else {
+        String::new()
+    };
 
     Ok(Json(ApiResponse {
         data: updated_agent,
         notification: Some(NotificationPayload {
-            message: format!("Went to sleep in {}.", bed.name),
+            message: format!(
+                "{}went to sleep in {}. {}.",
+                payment_prefix,
+                bed.name,
+                recovery_reason(&sleep_plan)
+            ),
             mode: NotificationMode::Instant,
             eta_seconds: None,
         }),
@@ -268,9 +391,6 @@ pub async fn wake_up(
         ));
     }
 
-    // Apply sleep recovery (sleep_level recovers, other vitals still decay)
-    let agent = crate::routes::vitals::apply_sleep_recovery_tx(&mut tx, &agent_id).await?;
-
     let occupied_beds = sqlx::query_as::<_, WorldObject>(
         r#"
         SELECT id, name, location_id, state, actions
@@ -283,6 +403,38 @@ pub async fn wake_up(
     .bind(&agent.id)
     .fetch_all(&mut *tx)
     .await?;
+
+    let empty_state = Value::Null;
+    let sleep_plan = match occupied_beds.first() {
+        Some(bed) => {
+            crate::routes::vitals::sleep_recovery_plan_for_bed_tx(
+                &mut tx,
+                &agent.id,
+                bed.location_id.as_deref(),
+                &bed.state,
+            )
+            .await?
+        }
+        None => {
+            crate::routes::vitals::sleep_recovery_plan_for_bed_tx(
+                &mut tx,
+                &agent.id,
+                Some(&agent.current_location_id),
+                &empty_state,
+            )
+            .await?
+        }
+    };
+
+    let sleep_before = agent.sleep_level;
+    let stamina_before = agent.stamina_level;
+
+    let agent =
+        crate::routes::vitals::apply_sleep_recovery_with_plan_tx(&mut tx, &agent_id, &sleep_plan)
+            .await?;
+
+    let sleep_delta = agent.sleep_level - sleep_before;
+    let stamina_delta = agent.stamina_level - stamina_before;
 
     for bed in &occupied_beds {
         let mut bed_state = normalize_bed_state(&bed.state);
@@ -333,6 +485,12 @@ pub async fn wake_up(
             "agent_id": agent.id,
             "bed_id": bed_id,
             "location_id": agent.current_location_id,
+            "housing_tier": &sleep_plan.tier,
+            "recovery_reason": recovery_reason(&sleep_plan),
+            "sleep_recovery_per_min": sleep_plan.sleep_recovery_per_min,
+            "stamina_recovery_per_min": sleep_plan.stamina_recovery_per_min,
+            "sleep_delta": sleep_delta,
+            "stamina_delta": stamina_delta,
         })
         .to_string(),
     )
@@ -343,7 +501,10 @@ pub async fn wake_up(
     let targets = location_targets(&mut tx, &agent.current_location_id, &agent.id).await?;
     let mut citizen_signal_targets = Vec::new();
 
-    for target_agent_id in targets.iter().filter(|target| target.as_str() != agent.id.as_str()) {
+    for target_agent_id in targets
+        .iter()
+        .filter(|target| target.as_str() != agent.id.as_str())
+    {
         let enqueued = enqueue_citizen_wake_tx(
             &mut tx,
             target_agent_id,
@@ -355,6 +516,10 @@ pub async fn wake_up(
                     "agent_id": agent.id,
                     "bed_id": bed_id,
                     "location_id": agent.current_location_id,
+                    "housing_tier": &sleep_plan.tier,
+                    "recovery_reason": recovery_reason(&sleep_plan),
+                    "sleep_delta": sleep_delta,
+                    "stamina_delta": stamina_delta,
                 }
             }),
             format!("{} just woke up.", agent.name),
@@ -364,6 +529,10 @@ pub async fn wake_up(
                 "agent_name": agent.name,
                 "bed_id": bed_id,
                 "location_id": agent.current_location_id,
+                "housing_tier": &sleep_plan.tier,
+                "recovery_reason": recovery_reason(&sleep_plan),
+                "sleep_delta": sleep_delta,
+                "stamina_delta": stamina_delta,
             }),
             json!([]),
             true,
@@ -400,13 +569,23 @@ pub async fn wake_up(
             "agent_id": updated_agent.id,
             "bed_id": bed_id,
             "location_id": updated_agent.current_location_id,
+            "housing_tier": &sleep_plan.tier,
+            "recovery_reason": recovery_reason(&sleep_plan),
+            "sleep_delta": sleep_delta,
+            "stamina_delta": stamina_delta,
         }),
     ));
 
     Ok(Json(ApiResponse {
         data: updated_agent,
         notification: Some(NotificationPayload {
-            message: "Woke up and returned to idle.".to_string(),
+            message: format!(
+                "Woke up after {} sleep: sleep {:+}, stamina {:+}. {}.",
+                sleep_plan.label,
+                sleep_delta,
+                stamina_delta,
+                recovery_reason(&sleep_plan)
+            ),
             mode: NotificationMode::Instant,
             eta_seconds: None,
         }),

--- a/world-api/src/routes/vitals.rs
+++ b/world-api/src/routes/vitals.rs
@@ -12,11 +12,34 @@ const SLEEP_DECAY_PER_MIN: f64 = 0.2;
 const HYGIENE_DECAY_PER_MIN: f64 = 0.2;
 const APPEARANCE_DECAY_PER_MIN: f64 = 0.15;
 
-/// Sleep recovery rate per minute
-const SLEEP_RECOVERY_PER_MIN: f64 = 2.0;
+/// Default sleep recovery rates per minute, used when a sleeping agent has no
+/// occupied bed metadata. Concrete beds can override these through JSON state.
+const STANDARD_SLEEP_RECOVERY_PER_MIN: f64 = 2.0;
+const STANDARD_STAMINA_RECOVERY_PER_MIN: f64 = 0.5;
+
+const HOME_SLEEP_RECOVERY_PER_MIN: f64 = 3.0;
+const HOME_STAMINA_RECOVERY_PER_MIN: f64 = 1.2;
+
+const DORM_SLEEP_RECOVERY_PER_MIN: f64 = 2.4;
+const DORM_STAMINA_RECOVERY_PER_MIN: f64 = 0.9;
+
+const MOTEL_SLEEP_RECOVERY_PER_MIN: f64 = 2.0;
+const MOTEL_STAMINA_RECOVERY_PER_MIN: f64 = 0.7;
+
+const CAMPGROUND_SLEEP_RECOVERY_PER_MIN: f64 = 1.0;
+const CAMPGROUND_STAMINA_RECOVERY_PER_MIN: f64 = 0.4;
 
 /// Stamina cost for moving to an adjacent location
 pub const MOVE_STAMINA_COST: i16 = 5;
+
+#[derive(Debug, Clone)]
+pub struct SleepRecoveryPlan {
+    pub tier: String,
+    pub label: String,
+    pub sleep_recovery_per_min: f64,
+    pub stamina_recovery_per_min: f64,
+    pub cost_cents: i64,
+}
 
 /// Apply time-based vitals changes for an agent.
 /// Automatically selects decay or recovery based on agent state.
@@ -35,9 +58,10 @@ pub async fn apply_vitals_decay_tx(
     .fetch_one(&mut **tx)
     .await?;
 
-    // If sleeping, apply recovery instead of decay
+    // If sleeping, apply housing-aware recovery instead of decay.
     if agent.state == "sleeping" {
-        return apply_sleep_recovery_inner(tx, agent).await;
+        let plan = sleep_recovery_plan_for_current_bed_tx(tx, &agent).await?;
+        return apply_sleep_recovery_inner(tx, agent, &plan).await;
     }
 
     apply_decay_inner(tx, agent).await
@@ -46,6 +70,7 @@ pub async fn apply_vitals_decay_tx(
 /// Apply vitals decay + sleep recovery for a sleeping agent.
 /// Food/water/stamina still decay while sleeping; sleep_level recovers.
 /// Uses FOR UPDATE to prevent concurrent race conditions.
+#[allow(dead_code)]
 pub async fn apply_sleep_recovery_tx(
     tx: &mut Transaction<'_, Postgres>,
     agent_id: &str,
@@ -64,14 +89,71 @@ pub async fn apply_sleep_recovery_tx(
         return apply_decay_inner(tx, agent).await;
     }
 
-    apply_sleep_recovery_inner(tx, agent).await
+    let plan = sleep_recovery_plan_for_current_bed_tx(tx, &agent).await?;
+    apply_sleep_recovery_inner(tx, agent, &plan).await
+}
+
+pub async fn apply_sleep_recovery_with_plan_tx(
+    tx: &mut Transaction<'_, Postgres>,
+    agent_id: &str,
+    plan: &SleepRecoveryPlan,
+) -> AppResult<Agent> {
+    let agent = sqlx::query_as::<_, Agent>(
+        r#"
+        SELECT * FROM agents WHERE id = $1 FOR UPDATE
+        "#,
+    )
+    .bind(agent_id)
+    .fetch_one(&mut **tx)
+    .await?;
+
+    if agent.state != "sleeping" {
+        return apply_decay_inner(tx, agent).await;
+    }
+
+    apply_sleep_recovery_inner(tx, agent, plan).await
+}
+
+pub async fn sleep_recovery_plan_for_bed_tx(
+    tx: &mut Transaction<'_, Postgres>,
+    agent_id: &str,
+    location_id: Option<&str>,
+    bed_state: &serde_json::Value,
+) -> AppResult<SleepRecoveryPlan> {
+    let inferred_tier = match bed_state
+        .get("housing_tier")
+        .and_then(|value| value.as_str())
+    {
+        Some(value) if !value.trim().is_empty() => value.trim().to_string(),
+        _ => infer_housing_tier_for_location_tx(tx, agent_id, location_id).await?,
+    };
+
+    let mut plan = plan_for_tier(&inferred_tier);
+
+    if let Some(value) = bed_state
+        .get("sleep_recovery_per_min")
+        .and_then(|value| value.as_f64())
+    {
+        plan.sleep_recovery_per_min = value;
+    }
+    if let Some(value) = bed_state
+        .get("stamina_recovery_per_min")
+        .and_then(|value| value.as_f64())
+    {
+        plan.stamina_recovery_per_min = value;
+    }
+    if let Some(value) = bed_state
+        .get("nightly_price_cents")
+        .and_then(|value| value.as_i64())
+    {
+        plan.cost_cents = value.max(0);
+    }
+
+    Ok(plan)
 }
 
 /// Inner: apply awake decay. Takes an already-fetched agent (row is locked).
-async fn apply_decay_inner(
-    tx: &mut Transaction<'_, Postgres>,
-    agent: Agent,
-) -> AppResult<Agent> {
+async fn apply_decay_inner(tx: &mut Transaction<'_, Postgres>, agent: Agent) -> AppResult<Agent> {
     let now = Utc::now();
     let elapsed = (now - agent.last_vitals_update).num_seconds().max(0) as f64 / 60.0;
 
@@ -80,15 +162,34 @@ async fn apply_decay_inner(
         return Ok(agent);
     }
 
-    let new_food = ((agent.food_level as f64) - FOOD_DECAY_PER_MIN * elapsed).round().clamp(0.0, 100.0) as i16;
-    let new_water = ((agent.water_level as f64) - WATER_DECAY_PER_MIN * elapsed).round().clamp(0.0, 100.0) as i16;
-    let new_stamina = ((agent.stamina_level as f64) - STAMINA_DECAY_PER_MIN * elapsed).round().clamp(0.0, 100.0) as i16;
-    let new_sleep = ((agent.sleep_level as f64) - SLEEP_DECAY_PER_MIN * elapsed).round().clamp(0.0, 100.0) as i16;
-    let new_hygiene = ((agent.hygiene_level as f64) - HYGIENE_DECAY_PER_MIN * elapsed).round().clamp(0.0, 100.0) as i16;
+    let new_food = ((agent.food_level as f64) - FOOD_DECAY_PER_MIN * elapsed)
+        .round()
+        .clamp(0.0, 100.0) as i16;
+    let new_water = ((agent.water_level as f64) - WATER_DECAY_PER_MIN * elapsed)
+        .round()
+        .clamp(0.0, 100.0) as i16;
+    let new_stamina = ((agent.stamina_level as f64) - STAMINA_DECAY_PER_MIN * elapsed)
+        .round()
+        .clamp(0.0, 100.0) as i16;
+    let new_sleep = ((agent.sleep_level as f64) - SLEEP_DECAY_PER_MIN * elapsed)
+        .round()
+        .clamp(0.0, 100.0) as i16;
+    let new_hygiene = ((agent.hygiene_level as f64) - HYGIENE_DECAY_PER_MIN * elapsed)
+        .round()
+        .clamp(0.0, 100.0) as i16;
 
     // Appearance decays faster when hygiene is low, slower when hygiene is high
-    let appearance_modifier = if agent.hygiene_level < 20 { 2.0 } else if agent.hygiene_level > 80 { 0.5 } else { 1.0 };
-    let new_appearance = ((agent.appearance_level as f64) - APPEARANCE_DECAY_PER_MIN * appearance_modifier * elapsed).round().clamp(0.0, 100.0) as i16;
+    let appearance_modifier = if agent.hygiene_level < 20 {
+        2.0
+    } else if agent.hygiene_level > 80 {
+        0.5
+    } else {
+        1.0
+    };
+    let new_appearance = ((agent.appearance_level as f64)
+        - APPEARANCE_DECAY_PER_MIN * appearance_modifier * elapsed)
+        .round()
+        .clamp(0.0, 100.0) as i16;
 
     let updated = sqlx::query_as::<_, Agent>(
         r#"
@@ -123,6 +224,7 @@ async fn apply_decay_inner(
 async fn apply_sleep_recovery_inner(
     tx: &mut Transaction<'_, Postgres>,
     agent: Agent,
+    plan: &SleepRecoveryPlan,
 ) -> AppResult<Agent> {
     let now = Utc::now();
     let elapsed = (now - agent.last_vitals_update).num_seconds().max(0) as f64 / 60.0;
@@ -131,17 +233,36 @@ async fn apply_sleep_recovery_inner(
         return Ok(agent);
     }
 
-    // Food/water/stamina still decay while sleeping
-    let new_food = ((agent.food_level as f64) - FOOD_DECAY_PER_MIN * elapsed).round().clamp(0.0, 100.0) as i16;
-    let new_water = ((agent.water_level as f64) - WATER_DECAY_PER_MIN * elapsed).round().clamp(0.0, 100.0) as i16;
-    let new_stamina = ((agent.stamina_level as f64) - STAMINA_DECAY_PER_MIN * elapsed).round().clamp(0.0, 100.0) as i16;
-    // Sleep level recovers while sleeping
-    let new_sleep = ((agent.sleep_level as f64) + SLEEP_RECOVERY_PER_MIN * elapsed).round().clamp(0.0, 100.0) as i16;
+    // Food and water still decay while sleeping.
+    let new_food = ((agent.food_level as f64) - FOOD_DECAY_PER_MIN * elapsed)
+        .round()
+        .clamp(0.0, 100.0) as i16;
+    let new_water = ((agent.water_level as f64) - WATER_DECAY_PER_MIN * elapsed)
+        .round()
+        .clamp(0.0, 100.0) as i16;
+    let stamina_delta = (plan.stamina_recovery_per_min - STAMINA_DECAY_PER_MIN) * elapsed;
+    let new_stamina = ((agent.stamina_level as f64) + stamina_delta)
+        .round()
+        .clamp(0.0, 100.0) as i16;
+    let new_sleep = ((agent.sleep_level as f64) + plan.sleep_recovery_per_min * elapsed)
+        .round()
+        .clamp(0.0, 100.0) as i16;
     // Hygiene decays slower while sleeping
-    let new_hygiene = ((agent.hygiene_level as f64) - HYGIENE_DECAY_PER_MIN * 0.5 * elapsed).round().clamp(0.0, 100.0) as i16;
+    let new_hygiene = ((agent.hygiene_level as f64) - HYGIENE_DECAY_PER_MIN * 0.5 * elapsed)
+        .round()
+        .clamp(0.0, 100.0) as i16;
     // Appearance decays slower while sleeping
-    let appearance_modifier = if agent.hygiene_level < 20 { 2.0 } else if agent.hygiene_level > 80 { 0.5 } else { 1.0 };
-    let new_appearance = ((agent.appearance_level as f64) - APPEARANCE_DECAY_PER_MIN * appearance_modifier * 0.5 * elapsed).round().clamp(0.0, 100.0) as i16;
+    let appearance_modifier = if agent.hygiene_level < 20 {
+        2.0
+    } else if agent.hygiene_level > 80 {
+        0.5
+    } else {
+        1.0
+    };
+    let new_appearance = ((agent.appearance_level as f64)
+        - APPEARANCE_DECAY_PER_MIN * appearance_modifier * 0.5 * elapsed)
+        .round()
+        .clamp(0.0, 100.0) as i16;
 
     let updated = sqlx::query_as::<_, Agent>(
         r#"
@@ -170,4 +291,144 @@ async fn apply_sleep_recovery_inner(
     .await?;
 
     Ok(updated)
+}
+
+async fn sleep_recovery_plan_for_current_bed_tx(
+    tx: &mut Transaction<'_, Postgres>,
+    agent: &Agent,
+) -> AppResult<SleepRecoveryPlan> {
+    let occupied_bed = sqlx::query_as::<_, (Option<String>, serde_json::Value)>(
+        r#"
+        SELECT location_id, state
+        FROM world_objects
+        WHERE state->>'occupied_by' = $1
+        ORDER BY id
+        LIMIT 1
+        "#,
+    )
+    .bind(&agent.id)
+    .fetch_optional(&mut **tx)
+    .await?;
+
+    match occupied_bed {
+        Some((location_id, bed_state)) => {
+            sleep_recovery_plan_for_bed_tx(tx, &agent.id, location_id.as_deref(), &bed_state).await
+        }
+        None => {
+            sleep_recovery_plan_for_bed_tx(
+                tx,
+                &agent.id,
+                Some(&agent.current_location_id),
+                &serde_json::Value::Null,
+            )
+            .await
+        }
+    }
+}
+
+async fn infer_housing_tier_for_location_tx(
+    tx: &mut Transaction<'_, Postgres>,
+    agent_id: &str,
+    location_id: Option<&str>,
+) -> AppResult<String> {
+    let Some(location_id) = location_id else {
+        return Ok("standard".to_string());
+    };
+
+    if location_id == "smallville_campground" {
+        return Ok("campground".to_string());
+    }
+    if location_id == "smallville_motel_room" || location_id == "smallville_motel_lobby" {
+        return Ok("motel".to_string());
+    }
+
+    let location_role = sqlx::query_as::<_, (String, Option<i32>)>(
+        r#"
+        SELECT lr.role, l.capacity
+        FROM location_roles lr
+        JOIN locations l ON l.id = lr.location_id
+        WHERE lr.agent_id = $1
+          AND lr.location_id = $2
+          AND lr.role IN ('resident', 'owner', 'tenant')
+        ORDER BY CASE lr.role
+            WHEN 'owner' THEN 1
+            WHEN 'resident' THEN 2
+            WHEN 'tenant' THEN 3
+            ELSE 4
+        END
+        LIMIT 1
+        "#,
+    )
+    .bind(agent_id)
+    .bind(location_id)
+    .fetch_optional(&mut **tx)
+    .await?;
+
+    Ok(match location_role {
+        Some((_role, Some(_capacity))) => "dorm".to_string(),
+        Some((_role, None)) => "home".to_string(),
+        None => "standard".to_string(),
+    })
+}
+
+fn plan_for_tier(tier: &str) -> SleepRecoveryPlan {
+    match tier {
+        "home" | "owned_home" => SleepRecoveryPlan {
+            tier: "home".to_string(),
+            label: "owned home".to_string(),
+            sleep_recovery_per_min: HOME_SLEEP_RECOVERY_PER_MIN,
+            stamina_recovery_per_min: HOME_STAMINA_RECOVERY_PER_MIN,
+            cost_cents: 0,
+        },
+        "dorm" => SleepRecoveryPlan {
+            tier: "dorm".to_string(),
+            label: "dorm bed".to_string(),
+            sleep_recovery_per_min: DORM_SLEEP_RECOVERY_PER_MIN,
+            stamina_recovery_per_min: DORM_STAMINA_RECOVERY_PER_MIN,
+            cost_cents: 0,
+        },
+        "motel" => SleepRecoveryPlan {
+            tier: "motel".to_string(),
+            label: "motel room".to_string(),
+            sleep_recovery_per_min: MOTEL_SLEEP_RECOVERY_PER_MIN,
+            stamina_recovery_per_min: MOTEL_STAMINA_RECOVERY_PER_MIN,
+            cost_cents: 2_500,
+        },
+        "campground" => SleepRecoveryPlan {
+            tier: "campground".to_string(),
+            label: "campground".to_string(),
+            sleep_recovery_per_min: CAMPGROUND_SLEEP_RECOVERY_PER_MIN,
+            stamina_recovery_per_min: CAMPGROUND_STAMINA_RECOVERY_PER_MIN,
+            cost_cents: 0,
+        },
+        _ => SleepRecoveryPlan {
+            tier: "standard".to_string(),
+            label: "standard bed".to_string(),
+            sleep_recovery_per_min: STANDARD_SLEEP_RECOVERY_PER_MIN,
+            stamina_recovery_per_min: STANDARD_STAMINA_RECOVERY_PER_MIN,
+            cost_cents: 0,
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn housing_tiers_have_distinct_sleep_and_stamina_recovery() {
+        let home = plan_for_tier("home");
+        let motel = plan_for_tier("motel");
+        let campground = plan_for_tier("campground");
+
+        assert!(home.sleep_recovery_per_min > motel.sleep_recovery_per_min);
+        assert!(motel.sleep_recovery_per_min > campground.sleep_recovery_per_min);
+
+        assert!(home.stamina_recovery_per_min > motel.stamina_recovery_per_min);
+        assert!(motel.stamina_recovery_per_min > campground.stamina_recovery_per_min);
+
+        assert_eq!(home.cost_cents, 0);
+        assert!(motel.cost_cents > 0);
+        assert_eq!(campground.cost_cents, 0);
+    }
 }


### PR DESCRIPTION
## Summary

- Adds campground and motel lodging locations, objects, and map adjacency for free fallback sleep and paid temporary housing.
- Makes sleep and wake recovery housing-aware across owned home, dorm, motel, campground, and standard beds, with recovery reasons in events and notifications.
- Charges motel sleep through the economy ledger, exposes clear insufficient-funds details, and sends newly approved agents to the campground when dorms are full.
- Applies dorm and location-role seed files during bootstrap so owned-home recovery works in fresh deployments.

Closes #63.
Closes #64.
Closes #65.

"Housing should make sleep a choice, not a reset button."

Written by Cameron ◯ Letta Code