### PR TITLE
Derive seed FK validation from migrations

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -110,6 +110,11 @@ If your PR changes any file in `seed/`:
    node scripts/validate-seeds.mjs
    ```
 
+   Foreign-key checks are derived automatically from the migration schema in
+   `world-api/migrations/`, so adding seed data for a new FK-bearing table needs
+   no manual rule changes — just run the linter (and its tests) to confirm the
+   new references resolve.
+
 2. **Run the bootstrap smoke test** — proves the full migration + seed sequence
    works on a fresh database (requires Docker and a Bash-compatible shell
    such as Git Bash, WSL, macOS, or Linux):

--- a/scripts/validate-seeds.mjs
+++ b/scripts/validate-seeds.mjs
@@ -6,7 +6,8 @@
 //   1. column-count    — VALUES tuple count matches column list
 //   2. double-quote    — flags "string" in VALUES (likely meant 'string')
 //   3. jsonb           — parses every '...'::jsonb literal with JSON.parse
-//   4. fk-ref          — order-aware FK reference check against seed-order.txt
+//   4. fk-ref          — order-aware FK reference check; FK rules are derived
+//                        from world-api/migrations and checked against seed-order.txt
 //   5. adjacency-symmetry — every (A,B) edge has a (B,A) reverse
 //   6. inventory-xor   — inventory_items: exactly one of held_by/location_id is non-NULL
 //   7. consumable      — consumable_type must be in allowed set; vital_value/quantity > 0
@@ -191,8 +192,17 @@ function parseInserts(sql, fileName) {
   let match;
 
   while ((match = insertRegex.exec(stripped)) !== null) {
-    const table = match[1];
-    const columns = match[2].split(',').map(c => c.trim()).filter(Boolean);
+    // Postgres folds unquoted identifiers to lowercase, so normalize the
+    // table name and column names. This keeps seed inserts and the
+    // migration-derived FK rules joinable regardless of source casing
+    // (e.g. `INSERT INTO AGENTS` matches a rule keyed on `agents`).
+    // NOTE: only identifiers are folded here — VALUE literals are left
+    // untouched (they are case-sensitive TEXT and handled in unquoteValue).
+    const table = match[1].toLowerCase();
+    const columns = match[2]
+      .split(',')
+      .map(c => c.trim().toLowerCase())
+      .filter(Boolean);
     const afterValues = stripped.slice(match.index + match[0].length);
 
     // Find the end of the VALUES section: look for ON CONFLICT or ; at depth 0
@@ -233,6 +243,111 @@ function parseInserts(sql, fileName) {
   }
 
   return inserts;
+}
+
+/**
+ * Derive foreign-key rules from the migration SQL files.
+ *
+ * This replaces the previously hardcoded `fkRules` list so the FK check
+ * stays in sync with the schema automatically — adding seed data for a new
+ * FK-bearing table no longer requires hand-editing a parallel rule list.
+ *
+ * Project-specific extractor for the FK shapes used in this repo (not a
+ * general SQL parser). It recognizes the two FK shapes this project uses:
+ *
+ *   1. Inline column FK inside CREATE TABLE:
+ *        <col> <type> [NOT NULL | PRIMARY KEY] REFERENCES <table>(<col>)
+ *   2. ALTER TABLE add-column FK:
+ *        ALTER TABLE <t> ADD COLUMN <col> <type> ... REFERENCES <table>(<col>);
+ *
+ * The project uses no table-level `FOREIGN KEY (...)` constraints, so those
+ * are intentionally not parsed. If that changes, add a targeted branch + test.
+ *
+ * Identifier handling: all source/target table and column identifiers are
+ * lowercased, matching Postgres unquoted-identifier folding and the seed
+ * insert parser, so rules and seed inserts join regardless of source casing.
+ *
+ * Nullability: `NOT NULL` or `PRIMARY KEY` on the source column => non-null;
+ * otherwise nullable. Nullable FK columns allow NULL values; non-null FK
+ * columns with an explicit NULL value are a violation.
+ *
+ * @param {string} migrationsDir — path to world-api/migrations
+ * @returns {Array<{ sourceTable, column, targetTable, targetColumn, nullable }>}
+ */
+export function deriveFkRules(migrationsDir) {
+  const files = readdirSync(migrationsDir)
+    .filter(f => f.endsWith('.sql'))
+    .sort();
+
+  const rules = [];
+  const seen = new Set(); // dedupe on sourceTable.column
+
+  for (const file of files) {
+    const raw = readFileSync(join(migrationsDir, file), 'utf-8');
+    const sql = stripComments(raw); // strip BEFORE matching so commented-out REFERENCES are ignored
+
+    // ── Inline FKs inside CREATE TABLE blocks ──────────────────────────
+    // Walk CREATE TABLE <name> ( ... ); blocks, tracking the current table,
+    // and scan each block for column definitions that contain REFERENCES.
+    const createRe = /CREATE\s+TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?(\w+)\s*\(/gi;
+    let cm;
+    while ((cm = createRe.exec(sql)) !== null) {
+      const sourceTable = cm[1].toLowerCase();
+      // Find the matching close paren for this table's column block.
+      let depth = 0;
+      let blockStart = cm.index + cm[0].length - 1; // at the '('
+      let blockEnd = sql.length;
+      for (let i = blockStart; i < sql.length; i++) {
+        if (sql[i] === '(') depth++;
+        else if (sql[i] === ')') {
+          depth--;
+          if (depth === 0) { blockEnd = i; break; }
+        }
+      }
+      const block = sql.slice(blockStart + 1, blockEnd);
+      // Match a column definition line that has a REFERENCES clause.
+      // <col> <type-stuff> REFERENCES <table>(<col>)
+      const colRefRe =
+        /(\w+)\s+[^,]*?\bREFERENCES\s+(\w+)\s*\(\s*(\w+)\s*\)/gi;
+      let rm;
+      while ((rm = colRefRe.exec(block)) !== null) {
+        const column = rm[1].toLowerCase();
+        const targetTable = rm[2].toLowerCase();
+        const targetColumn = rm[3].toLowerCase();
+        // Nullability: inspect the text of this column def up to REFERENCES.
+        const defPrefix = block.slice(rm.index, rm.index + rm[0].length);
+        const nullable =
+          !/\bNOT\s+NULL\b/i.test(defPrefix) &&
+          !/\bPRIMARY\s+KEY\b/i.test(defPrefix);
+        addRule(sourceTable, column, targetTable, targetColumn, nullable);
+      }
+    }
+
+    // ── ALTER TABLE ... ADD COLUMN ... REFERENCES ... ──────────────────
+    const alterRe =
+      /ALTER\s+TABLE\s+(\w+)\s+ADD\s+COLUMN\s+(?:IF\s+NOT\s+EXISTS\s+)?(\w+)\s+[^;]*?\bREFERENCES\s+(\w+)\s*\(\s*(\w+)\s*\)/gi;
+    let am;
+    while ((am = alterRe.exec(sql)) !== null) {
+      const sourceTable = am[1].toLowerCase();
+      const column = am[2].toLowerCase();
+      const targetTable = am[3].toLowerCase();
+      const targetColumn = am[4].toLowerCase();
+      const stmt = am[0];
+      const nullable =
+        !/\bNOT\s+NULL\b/i.test(stmt) &&
+        !/\bPRIMARY\s+KEY\b/i.test(stmt);
+      addRule(sourceTable, column, targetTable, targetColumn, nullable);
+    }
+  }
+
+  return rules;
+
+  function addRule(sourceTable, column, targetTable, targetColumn, nullable) {
+    const key = `${sourceTable}.${column}`;
+    if (seen.has(key)) return; // first definition wins (CREATE before later ALTERs)
+    seen.add(key);
+    rules.push({ sourceTable, column, targetTable, targetColumn, nullable });
+  }
 }
 
 /**
@@ -346,13 +461,19 @@ const ALLOWED_CONSUMABLE_TYPES = new Set([
 
 /**
  * Main validation function.
+ *
+ * Synchronous: all I/O is readFileSync/readdirSync. (Previously declared
+ * `async` despite never awaiting; the signature was misleading.)
+ *
  * @param {string} seedDir — path to the seed/ directory
- * @param {object} opts — { seedOrderPath?: string }
+ * @param {object} opts — { seedOrderPath?: string, migrationsDir?: string }
  * @returns {{ failures: Array<{ check: string, file: string, line: number, message: string }> }}
  */
-export async function validateSeeds(seedDir, opts = {}) {
+export function validateSeeds(seedDir, opts = {}) {
   const seedOrderPath = opts.seedOrderPath
     ?? join(__dirname, 'seed-order.txt');
+  const migrationsDir = opts.migrationsDir
+    ?? join(__dirname, '..', 'world-api', 'migrations');
 
   const failures = [];
 
@@ -455,94 +576,129 @@ export async function validateSeeds(seedDir, opts = {}) {
     }
   }
 
-  // ── Check 4: FK reference inventory (order-aware) ──────────────────────
-  // Accumulating ID sets, built up as we process files in seed-order.
-  // For each file: collect its own IDs first (so intra-file references
-  // resolve), then check FK columns against IDs available from previous
-  // files plus this file's own IDs, then merge into the accumulated sets.
-  const idSets = {
-    locations: new Set(),   // locations + dorms both insert into 'locations'
-    agents: new Set(),
-    jobs: new Set(),
+  // ── Check 4: FK reference inventory (order-aware, migration-derived) ────
+  // FK rules are derived from the migration schema rather than hand-listed,
+  // so the check stays in sync with the schema automatically. The order-aware
+  // engine below is unchanged in behavior: a referenced value is valid only
+  // if it was loaded by an earlier seed file or appears in the same file.
+  // This preserves the order-sensitive check for references loaded too late.
+  //
+  // Target availability is tracked by `table.column` (not bare table name),
+  // because FK targets are not always `id` (e.g. citizen_wakes(event_id)) and
+  // multiple seed files can feed one table (dorms.sql inserts into locations).
+  let fkRules = [];
+  try {
+    fkRules = deriveFkRules(migrationsDir);
+  } catch (e) {
+    // No migrations available => cannot derive FK rules. Skip the FK check
+    // rather than crash. (The seed-order / column / jsonb checks still run.)
+    fkRules = [];
+  }
+
+  // valueKey(table, column) → the dotted key used for target value sets.
+  const valueKey = (table, column) => `${table}.${column}`;
+
+  // We only need to inventory the table.column pairs that some FK rule
+  // actually points at. Collecting every column would be wasteful and
+  // wouldn't match how the values are consumed below.
+  const targetKeys = new Set(
+    fkRules.map(r => valueKey(r.targetTable, r.targetColumn))
+  );
+
+  // collectInto(map, inserts): add seeded values for FK-target columns into
+  // `map` ("table.column" → Set(values)). Skips NULLs (a NULL is not a value
+  // a reference can resolve to).
+  const collectInto = (map, inserts) => {
+    for (const ins of inserts) {
+      for (let ci = 0; ci < ins.columns.length; ci++) {
+        const key = valueKey(ins.table, ins.columns[ci]);
+        if (!targetKeys.has(key)) continue; // not referenced by any FK rule
+        let set = map.get(key);
+        if (!set) { set = new Set(); map.set(key, set); }
+        for (const tuple of ins.tuples) {
+          const values = splitTupleValues(tuple);
+          if (ci < values.length) {
+            const v = unquoteValue(values[ci]);
+            if (v !== null) set.add(v);
+          }
+        }
+      }
+    }
   };
 
-  // FK map: source table.column → target ID set, with nullable flag.
-  // Nullable FKs (shops.owner_id, banks.updated_by, etc.) are only
-  // checked when the value is non-NULL.
-  const fkRules = [
-    { sourceTable: 'location_adjacency', column: 'from_id', targetSet: 'locations' },
-    { sourceTable: 'location_adjacency', column: 'to_id', targetSet: 'locations' },
-    { sourceTable: 'world_objects', column: 'location_id', targetSet: 'locations' },
-    { sourceTable: 'inventory_items', column: 'location_id', targetSet: 'locations', nullable: true },
-    { sourceTable: 'inventory_items', column: 'held_by', targetSet: 'agents', nullable: true },
-    { sourceTable: 'agents', column: 'current_location_id', targetSet: 'locations' },
-    { sourceTable: 'agents', column: 'home_location_id', targetSet: 'locations', nullable: true },
-    { sourceTable: 'jobs', column: 'employer_id', targetSet: 'agents', nullable: true },
-    { sourceTable: 'agent_jobs', column: 'agent_id', targetSet: 'agents' },
-    { sourceTable: 'agent_jobs', column: 'job_id', targetSet: 'jobs' },
-    { sourceTable: 'location_roles', column: 'location_id', targetSet: 'locations' },
-    { sourceTable: 'location_roles', column: 'agent_id', targetSet: 'agents' },
-    { sourceTable: 'shops', column: 'owner_id', targetSet: 'agents', nullable: true },
-    { sourceTable: 'shops', column: 'shopkeeper_job_id', targetSet: 'jobs', nullable: true },
-    { sourceTable: 'banks', column: 'banker_job_id', targetSet: 'jobs', nullable: true },
-    { sourceTable: 'banks', column: 'updated_by', targetSet: 'agents', nullable: true },
-  ];
+  // Precompute which target table.column pairs have any seeded values across
+  // all seed files. This lets us distinguish two cases that look identical to
+  // a plain lookup:
+  //   • target never seeded anywhere  → skip the rule quietly (not an error)
+  //   • target seeded, but value not available up to this file → fail
+  //     (dangling reference or a reference loaded too late)
+  const globalTargetValues = new Map(); // "table.column" → Set(values)
+  for (const inserts of fileInserts.values()) {
+    collectInto(globalTargetValues, inserts);
+  }
+
+  // Accumulated available target values, built up in seed-order.
+  const availableTargetValues = new Map(); // "table.column" → Set(values)
 
   for (const fileName of seedOrderLines) {
     const inserts = fileInserts.get(fileName);
     if (!inserts) continue;
 
-    // Phase 1: collect all IDs this file introduces (so intra-file refs work)
-    const fileIds = { locations: new Set(), agents: new Set(), jobs: new Set() };
-    for (const ins of inserts) {
-      const idSetKey =
-        ins.table === 'locations' ? 'locations' :
-        ins.table === 'agents' ? 'agents' :
-        ins.table === 'jobs' ? 'jobs' :
-        null;
-      if (idSetKey) {
-        for (const tuple of ins.tuples) {
-          const values = splitTupleValues(tuple);
-          if (values.length > 0) {
-            const id = unquoteValue(values[0]);
-            if (id !== null) fileIds[idSetKey].add(id);
-          }
-        }
-      }
-    }
+    // Phase 1: collect target values THIS file introduces (so intra-file
+    // references resolve). Only columns that are actually FK targets.
+    const fileTargetValues = new Map(); // "table.column" → Set(values)
+    collectInto(fileTargetValues, inserts);
 
-    // Available IDs = accumulated from previous files + this file's own IDs
-    const availableSets = {
-      locations: new Set([...idSets.locations, ...fileIds.locations]),
-      agents: new Set([...idSets.agents, ...fileIds.agents]),
-      jobs: new Set([...idSets.jobs, ...fileIds.jobs]),
+    // available = accumulated-from-previous-files ∪ this-file's-own
+    const availableFor = (key) => {
+      const acc = availableTargetValues.get(key);
+      const own = fileTargetValues.get(key);
+      if (acc && own) return new Set([...acc, ...own]);
+      return acc ?? own ?? new Set();
     };
 
-    // Phase 2: check FK references against available IDs
+    // Phase 2: check FK references against available target values.
     for (const ins of inserts) {
       for (const rule of fkRules) {
         if (rule.sourceTable !== ins.table) continue;
         const colIdx = ins.columns.indexOf(rule.column);
         if (colIdx === -1) continue;
 
+        const targetKey = valueKey(rule.targetTable, rule.targetColumn);
+        // Graceful skip: if the target table.column is seeded nowhere, there
+        // is nothing to validate against (runtime-only table) — skip quietly.
+        if (!globalTargetValues.has(targetKey)) continue;
+
+        const available = availableFor(targetKey);
+
         for (let ti = 0; ti < ins.tuples.length; ti++) {
           const values = splitTupleValues(ins.tuples[ti]);
           if (colIdx >= values.length) continue;
           const rawVal = unquoteValue(values[colIdx]);
-          if (rawVal === null) continue; // NULL values skip FK check
-          if (!availableSets[rule.targetSet].has(rawVal)) {
+          if (rawVal === null) {
+            // NULL handling is driven by the migration-derived nullability:
+            //   • nullable FK column  → NULL is allowed, skip.
+            //   • non-null FK column  → explicit NULL violates the NOT NULL /
+            //     PRIMARY KEY constraint the FK is derived from → FAIL.
+            if (!rule.nullable) {
+              fail('fk-ref', fileName, ins.lineNumber,
+                `${ins.table} row ${ti + 1}: ${rule.column} is NULL but the schema declares it NOT NULL (FK to ${rule.targetTable}.${rule.targetColumn})`);
+            }
+            continue;
+          }
+          if (!available.has(rawVal)) {
             fail('fk-ref', fileName, ins.lineNumber,
-              `${ins.table} row ${ti + 1}: ${rule.column} '${rawVal}' not found in ${rule.targetSet} (loaded up to and including ${fileName})`);
+              `${ins.table} row ${ti + 1}: ${rule.column} '${rawVal}' not found in ${rule.targetTable}.${rule.targetColumn} (loaded up to and including ${fileName})`);
           }
         }
       }
     }
 
-    // Phase 3: merge this file's IDs into the accumulated sets
-    for (const key of Object.keys(fileIds)) {
-      for (const id of fileIds[key]) {
-        idSets[key].add(id);
-      }
+    // Phase 3: merge this file's values into the accumulated map.
+    for (const [key, set] of fileTargetValues) {
+      let acc = availableTargetValues.get(key);
+      if (!acc) { acc = new Set(); availableTargetValues.set(key, acc); }
+      for (const v of set) acc.add(v);
     }
   }
 
@@ -664,7 +820,7 @@ const isMain = process.argv[1] &&
 
 if (isMain) {
   const seedDir = join(__dirname, '..', 'seed');
-  const result = await validateSeeds(seedDir);
+  const result = validateSeeds(seedDir);
 
   for (const f of result.failures) {
     console.log(`FAIL  [${f.check}]  ${f.file}:${f.line}  ${f.message}`);

--- a/scripts/validate-seeds.test.mjs
+++ b/scripts/validate-seeds.test.mjs
@@ -13,11 +13,12 @@ import { tmpdir } from 'node:os';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-import { validateSeeds } from './validate-seeds.mjs';
+import { validateSeeds, deriveFkRules } from './validate-seeds.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const REAL_SEED_DIR = join(__dirname, '..', 'seed');
 const REAL_SEED_ORDER = join(__dirname, 'seed-order.txt');
+const REAL_MIGRATIONS_DIR = join(__dirname, '..', 'world-api', 'migrations');
 
 // ---------------------------------------------------------------------------
 // Fixture helpers
@@ -48,6 +49,43 @@ async function withFixture(seedDir, mutations, fn) {
   }
 }
 
+/**
+ * Create a temp seed directory from scratch (NOT a copy of the real seeds),
+ * write the given { fileName: content } map into it, run fn(tmpDir), then
+ * clean up. FK rules are derived from the REAL migrations by default (the
+ * validator resolves migrationsDir relative to the script, not the seed dir),
+ * which is what we want: small hand-built seed sets validated against the
+ * actual schema.
+ */
+async function withTempSeeds(files, fn) {
+  const tmp = await mkdtemp(join(tmpdir(), 'seed-temp-'));
+  try {
+    for (const [name, content] of Object.entries(files)) {
+      await writeFile(join(tmp, name), content);
+    }
+    await fn(tmp);
+  } finally {
+    await rm(tmp, { recursive: true, force: true });
+  }
+}
+
+/**
+ * Create a temp migrations directory with the given { fileName: content }
+ * map, run fn(tmpDir), then clean up. Used to exercise the migration FK
+ * parser in isolation.
+ */
+async function withTempMigrations(files, fn) {
+  const tmp = await mkdtemp(join(tmpdir(), 'migs-temp-'));
+  try {
+    for (const [name, content] of Object.entries(files)) {
+      await writeFile(join(tmp, name), content);
+    }
+    await fn(tmp);
+  } finally {
+    await rm(tmp, { recursive: true, force: true });
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Helper: read a real seed file
 // ---------------------------------------------------------------------------
@@ -70,7 +108,7 @@ describe('validate-seeds falsifiability', () => {
   // ── Control ─────────────────────────────────────────────────────────
   it('passes on unmodified real seeds (control)', async () => {
     await withFixture(REAL_SEED_DIR, {}, async (tmp) => {
-      const result = await validateSeeds(tmp, { seedOrderPath: REAL_SEED_ORDER });
+      const result = validateSeeds(tmp, { seedOrderPath: REAL_SEED_ORDER });
       assert.strictEqual(result.failures.length, 0,
         'Unmodified seeds must produce zero failures. Got:\n' +
         result.failures.map(f => `  ${f.check}: ${f.message}`).join('\n'));
@@ -88,7 +126,7 @@ describe('validate-seeds falsifiability', () => {
     assert.notStrictEqual(original, mutated, 'Mutation must change the file');
 
     await withFixture(REAL_SEED_DIR, { 'jobs.sql': mutated }, async (tmp) => {
-      const result = await validateSeeds(tmp, { seedOrderPath: REAL_SEED_ORDER });
+      const result = validateSeeds(tmp, { seedOrderPath: REAL_SEED_ORDER });
       const found = result.failures.some(f => f.check === 'column-count');
       assert.ok(found,
         'Must detect column-count mismatch — this is the PR #59 extra-value bug');
@@ -110,7 +148,7 @@ describe('validate-seeds falsifiability', () => {
       await writeFile(join(tmp, 'jobs.sql'), sql);
       await writeFile(join(tmp, 'seed-order.txt'), 'jobs.sql\n');
 
-      const result = await validateSeeds(tmp, {
+      const result = validateSeeds(tmp, {
         seedOrderPath: join(tmp, 'seed-order.txt'),
       });
 
@@ -134,7 +172,7 @@ describe('validate-seeds falsifiability', () => {
     assert.notStrictEqual(original, mutated, 'Mutation must change the file');
 
     await withFixture(REAL_SEED_DIR, { 'locations.sql': mutated }, async (tmp) => {
-      const result = await validateSeeds(tmp, { seedOrderPath: REAL_SEED_ORDER });
+      const result = validateSeeds(tmp, { seedOrderPath: REAL_SEED_ORDER });
       const found = result.failures.some(f => f.check === 'double-quote');
       assert.ok(found,
         'Must detect double-quoted string in VALUES — PR #59 regression class');
@@ -152,7 +190,7 @@ describe('validate-seeds falsifiability', () => {
     assert.notStrictEqual(original, mutated, 'Mutation must change the file');
 
     await withFixture(REAL_SEED_DIR, { 'jobs.sql': mutated }, async (tmp) => {
-      const result = await validateSeeds(tmp, { seedOrderPath: REAL_SEED_ORDER });
+      const result = validateSeeds(tmp, { seedOrderPath: REAL_SEED_ORDER });
       const found = result.failures.some(f => f.check === 'jsonb');
       assert.ok(found,
         'Must detect invalid JSONB literal — PR #59 regression class');
@@ -171,7 +209,7 @@ describe('validate-seeds falsifiability', () => {
     assert.notStrictEqual(original, mutated, 'Mutation must change the file');
 
     await withFixture(REAL_SEED_DIR, { 'agents.sql': mutated }, async (tmp) => {
-      const result = await validateSeeds(tmp, { seedOrderPath: REAL_SEED_ORDER });
+      const result = validateSeeds(tmp, { seedOrderPath: REAL_SEED_ORDER });
       const found = result.failures.some(f =>
         f.check === 'fk-ref' && f.message.includes('rosie_kim'));
       assert.ok(found,
@@ -191,7 +229,7 @@ describe('validate-seeds falsifiability', () => {
     await withFixture(REAL_SEED_DIR, {}, async (tmp) => {
       const mutatedOrderPath = join(tmp, 'seed-order.txt');
       await writeFile(mutatedOrderPath, mutatedOrder);
-      const result = await validateSeeds(tmp, { seedOrderPath: mutatedOrderPath });
+      const result = validateSeeds(tmp, { seedOrderPath: mutatedOrderPath });
       const found = result.failures.some(f => f.check === 'fk-ref');
       assert.ok(found,
         'Must detect FK ordering violation when agents.sql loads after shops.sql');
@@ -209,7 +247,7 @@ describe('validate-seeds falsifiability', () => {
     assert.notStrictEqual(original, mutated, 'Mutation must change the file');
 
     await withFixture(REAL_SEED_DIR, { 'adjacency.sql': mutated }, async (tmp) => {
-      const result = await validateSeeds(tmp, { seedOrderPath: REAL_SEED_ORDER });
+      const result = validateSeeds(tmp, { seedOrderPath: REAL_SEED_ORDER });
       const found = result.failures.some(f => f.check === 'adjacency-symmetry');
       assert.ok(found,
         'Must detect missing reverse adjacency edge');
@@ -227,7 +265,7 @@ describe('validate-seeds falsifiability', () => {
     assert.notStrictEqual(original, mutated, 'Mutation must change the file');
 
     await withFixture(REAL_SEED_DIR, { 'objects.sql': mutated }, async (tmp) => {
-      const result = await validateSeeds(tmp, { seedOrderPath: REAL_SEED_ORDER });
+      const result = validateSeeds(tmp, { seedOrderPath: REAL_SEED_ORDER });
       const found = result.failures.some(f => f.check === 'inventory-xor');
       assert.ok(found,
         'Must detect inventory XOR violation when both held_by and location_id are set');
@@ -245,7 +283,7 @@ describe('validate-seeds falsifiability', () => {
     assert.notStrictEqual(original, mutated, 'Mutation must change the file');
 
     await withFixture(REAL_SEED_DIR, { 'objects.sql': mutated }, async (tmp) => {
-      const result = await validateSeeds(tmp, { seedOrderPath: REAL_SEED_ORDER });
+      const result = validateSeeds(tmp, { seedOrderPath: REAL_SEED_ORDER });
       const found = result.failures.some(f =>
         f.check === 'consumable' && f.message.includes('magic'));
       assert.ok(found,
@@ -264,7 +302,7 @@ describe('validate-seeds falsifiability', () => {
     assert.notStrictEqual(original, mutated, 'Mutation must change the file');
 
     await withFixture(REAL_SEED_DIR, { 'objects.sql': mutated }, async (tmp) => {
-      const result = await validateSeeds(tmp, { seedOrderPath: REAL_SEED_ORDER });
+      const result = validateSeeds(tmp, { seedOrderPath: REAL_SEED_ORDER });
       const found = result.failures.some(f =>
         f.check === 'consumable' && f.message.includes('vital_value'));
       assert.ok(found,
@@ -277,7 +315,7 @@ describe('validate-seeds falsifiability', () => {
     await withFixture(REAL_SEED_DIR, {
       'fake_table.sql': "INSERT INTO fake (id) VALUES ('test');"
     }, async (tmp) => {
-      const result = await validateSeeds(tmp, { seedOrderPath: REAL_SEED_ORDER });
+      const result = validateSeeds(tmp, { seedOrderPath: REAL_SEED_ORDER });
       const found = result.failures.some(f =>
         f.check === 'seed-order' && f.message.includes('fake_table.sql'));
       assert.ok(found,
@@ -294,11 +332,307 @@ describe('validate-seeds falsifiability', () => {
     await withFixture(REAL_SEED_DIR, {}, async (tmp) => {
       const mutatedOrderPath = join(tmp, 'seed-order.txt');
       await writeFile(mutatedOrderPath, mutatedOrder);
-      const result = await validateSeeds(tmp, { seedOrderPath: mutatedOrderPath });
+      const result = validateSeeds(tmp, { seedOrderPath: mutatedOrderPath });
       const found = result.failures.some(f =>
         f.check === 'seed-order' && f.message.includes('phantom.sql'));
       assert.ok(found,
         'Must detect seed file listed in seed-order.txt but missing from seed/');
+    });
+  });
+
+  // ── FK rule coverage ───────────────────────────────────────────────
+  //
+  // The previous manual FK list covered these seeded relationships.
+  // Migration-derived rules should continue to cover the same source/target
+  // pairs. Nullability is tested separately because the old nullable flags
+  // were not enforced by the FK check.
+  it('derived FK rules cover the previously listed relationships', () => {
+    const expected = [
+      ['location_adjacency', 'from_id', 'locations', 'id'],
+      ['location_adjacency', 'to_id', 'locations', 'id'],
+      ['world_objects', 'location_id', 'locations', 'id'],
+      ['inventory_items', 'location_id', 'locations', 'id'],
+      ['inventory_items', 'held_by', 'agents', 'id'],
+      ['agents', 'current_location_id', 'locations', 'id'],
+      ['agents', 'home_location_id', 'locations', 'id'],
+      ['jobs', 'employer_id', 'agents', 'id'],
+      ['agent_jobs', 'agent_id', 'agents', 'id'],
+      ['agent_jobs', 'job_id', 'jobs', 'id'],
+      ['location_roles', 'location_id', 'locations', 'id'],
+      ['location_roles', 'agent_id', 'agents', 'id'],
+      ['shops', 'owner_id', 'agents', 'id'],
+      ['shops', 'shopkeeper_job_id', 'jobs', 'id'],
+      ['banks', 'banker_job_id', 'jobs', 'id'],
+      ['banks', 'updated_by', 'agents', 'id'],
+    ];
+
+    const derived = deriveFkRules(REAL_MIGRATIONS_DIR);
+    const derivedKeys = new Set(
+      derived.map(r => `${r.sourceTable}.${r.column}->${r.targetTable}.${r.targetColumn}`)
+    );
+
+    const missing = expected
+      .map(([st, c, tt, tc]) => `${st}.${c}->${tt}.${tc}`)
+      .filter(k => !derivedKeys.has(k));
+
+    assert.deepStrictEqual(missing, [],
+      'Derived FK rules no longer cover: ' + missing.join(', '));
+  });
+
+  // ── construction_projects coverage ─────────────────────────────────
+  //
+  // construction_projects.agent_id references agents(id) in
+  // 0020_construction.sql. construction_projects was not present in the
+  // previous manual rule list, so a bad agent_id there went unchecked.
+  // The derived rules should catch it.
+  it('fails on construction_projects with a bad agent_id', async () => {
+    const seedFiles = {
+      'agents.sql':
+        "INSERT INTO agents (id, current_location_id) VALUES ('eddy_lin', 'lin_bedroom');\n",
+      'locations.sql':
+        "INSERT INTO locations (id) VALUES ('lin_bedroom');\n",
+      'construction_companies.sql':
+        "INSERT INTO construction_companies (id) VALUES ('smallville_construction');\n",
+      'construction_projects.sql':
+        "INSERT INTO construction_projects (id, agent_id, company_id, location_id) " +
+        "VALUES ('proj_1', 'NOBODY', 'smallville_construction', 'lin_bedroom');\n",
+      'seed-order.txt':
+        'locations.sql\nagents.sql\nconstruction_companies.sql\nconstruction_projects.sql\n',
+    };
+    await withTempSeeds(seedFiles, async (tmp) => {
+      const result = validateSeeds(tmp, { seedOrderPath: join(tmp, 'seed-order.txt') });
+      const found = result.failures.some(f =>
+        f.check === 'fk-ref' && f.message.includes('NOBODY'));
+      assert.ok(found,
+        'Derived rules should catch a bad construction_projects.agent_id');
+    });
+  });
+
+  // Positive control: a fully valid construction_projects row should not
+  // false-positive on any of its three FK columns.
+  it('passes on a valid construction_projects row', async () => {
+    const seedFiles = {
+      'agents.sql':
+        "INSERT INTO agents (id, current_location_id) VALUES ('eddy_lin', 'lin_bedroom');\n",
+      'locations.sql':
+        "INSERT INTO locations (id) VALUES ('lin_bedroom');\n",
+      'construction_companies.sql':
+        "INSERT INTO construction_companies (id) VALUES ('smallville_construction');\n",
+      'construction_projects.sql':
+        "INSERT INTO construction_projects (id, agent_id, company_id, location_id) " +
+        "VALUES ('proj_1', 'eddy_lin', 'smallville_construction', 'lin_bedroom');\n",
+      'seed-order.txt':
+        'locations.sql\nagents.sql\nconstruction_companies.sql\nconstruction_projects.sql\n',
+    };
+    await withTempSeeds(seedFiles, async (tmp) => {
+      const result = validateSeeds(tmp, { seedOrderPath: join(tmp, 'seed-order.txt') });
+      const fkFailures = result.failures.filter(f => f.check === 'fk-ref');
+      assert.deepStrictEqual(fkFailures, [],
+        'Valid construction_projects row must not produce FK failures');
+    });
+  });
+
+  // ── PARSER SAFETY ──────────────────────────────────────────────────
+
+  it('parser: REFERENCES inside a -- comment does not create a rule', () => {
+    const migs = {
+      '0001.sql':
+        'CREATE TABLE foo (\n' +
+        '  id TEXT PRIMARY KEY,\n' +
+        '  -- bar_id TEXT REFERENCES bars(id),  (commented out, must be ignored)\n' +
+        '  real_id TEXT REFERENCES reals(id)\n' +
+        ');\n',
+    };
+    return withTempMigrations(migs, (dir) => {
+      const rules = deriveFkRules(dir);
+      assert.ok(rules.some(r => r.column === 'real_id' && r.targetTable === 'reals'),
+        'Real REFERENCES must be parsed');
+      assert.ok(!rules.some(r => r.targetTable === 'bars'),
+        'REFERENCES inside a -- comment should not produce a rule');
+    });
+  });
+
+  it('parser: PRIMARY KEY REFERENCES is treated as non-null', () => {
+    const migs = {
+      '0001.sql':
+        'CREATE TABLE citizen_runtime_state (\n' +
+        '  agent_id TEXT PRIMARY KEY REFERENCES agents(id) ON DELETE CASCADE\n' +
+        ');\n',
+    };
+    return withTempMigrations(migs, (dir) => {
+      const rules = deriveFkRules(dir);
+      const r = rules.find(x => x.sourceTable === 'citizen_runtime_state' && x.column === 'agent_id');
+      assert.ok(r, 'PK FK column must be parsed');
+      assert.strictEqual(r.nullable, false, 'PRIMARY KEY REFERENCES must be non-null');
+    });
+  });
+
+  it('parser: NOT NULL vs plain REFERENCES nullability is inferred correctly', () => {
+    const rules = deriveFkRules(REAL_MIGRATIONS_DIR);
+    const get = (st, c) => rules.find(r => r.sourceTable === st && r.column === c);
+    // Plain REFERENCES (no NOT NULL) => nullable
+    for (const [st, c] of [
+      ['inventory_items', 'held_by'],
+      ['inventory_items', 'location_id'],
+      ['jobs', 'employer_id'],
+      ['shops', 'owner_id'],
+      ['banks', 'updated_by'],
+    ]) {
+      assert.strictEqual(get(st, c)?.nullable, true, `${st}.${c} should be nullable`);
+    }
+    // NOT NULL REFERENCES => non-null
+    for (const [st, c] of [
+      ['agent_jobs', 'agent_id'],
+      ['location_roles', 'location_id'],
+      ['agents', 'current_location_id'],
+    ]) {
+      assert.strictEqual(get(st, c)?.nullable, false, `${st}.${c} should be non-null`);
+    }
+  });
+
+  it('nullability: nullable FK column with explicit NULL passes', async () => {
+    // agents.home_location_id is `TEXT REFERENCES locations(id)` (no NOT NULL),
+    // so an explicit NULL is allowed and should not fail.
+    const seedFiles = {
+      'locations.sql': "INSERT INTO locations (id) VALUES ('lin_bedroom');\n",
+      'agents.sql':
+        "INSERT INTO agents (id, current_location_id, home_location_id) " +
+        "VALUES ('eddy_lin', 'lin_bedroom', NULL);\n",
+      'seed-order.txt': 'locations.sql\nagents.sql\n',
+    };
+    await withTempSeeds(seedFiles, async (tmp) => {
+      const result = validateSeeds(tmp, { seedOrderPath: join(tmp, 'seed-order.txt') });
+      const fkFailures = result.failures.filter(f => f.check === 'fk-ref');
+      assert.deepStrictEqual(fkFailures, [],
+        'Explicit NULL in a nullable FK column must be allowed');
+    });
+  });
+
+  it('nullability: NON-null FK column with explicit NULL fails', async () => {
+    // agents.current_location_id is `TEXT NOT NULL REFERENCES locations(id)`,
+    // so an explicit NULL violates the derived non-null constraint and must fail.
+    const seedFiles = {
+      'locations.sql': "INSERT INTO locations (id) VALUES ('lin_bedroom');\n",
+      'agents.sql':
+        "INSERT INTO agents (id, current_location_id) VALUES ('eddy_lin', NULL);\n",
+      'seed-order.txt': 'locations.sql\nagents.sql\n',
+    };
+    await withTempSeeds(seedFiles, async (tmp) => {
+      const result = validateSeeds(tmp, { seedOrderPath: join(tmp, 'seed-order.txt') });
+      const found = result.failures.some(f =>
+        f.check === 'fk-ref' &&
+        f.message.includes('current_location_id') &&
+        /NULL/i.test(f.message));
+      assert.ok(found,
+        'Explicit NULL in a NOT NULL FK column should fail (derived nullability is enforced)');
+    });
+  });
+
+  it('parser: ALTER TABLE ADD COLUMN REFERENCES is accumulated (jobs.employer_id)', () => {
+    const rules = deriveFkRules(REAL_MIGRATIONS_DIR);
+    // jobs.employer_id is added via ALTER TABLE in 0012_job_system.sql, not in
+    // the CREATE TABLE for jobs — it must still be derived.
+    assert.ok(
+      rules.some(r => r.sourceTable === 'jobs' && r.column === 'employer_id' &&
+                      r.targetTable === 'agents' && r.targetColumn === 'id'),
+      'ALTER TABLE ADD COLUMN ... REFERENCES must be accumulated onto the base table');
+  });
+
+  it('identifiers: UPPERCASE unquoted table/column names normalize and still validate', async () => {
+    // Seed uses uppercase identifiers; Postgres folds them to lowercase, so
+    // the FK rule (agents.id) must still match a seeded value in AGENTS.ID.
+    const seedFiles = {
+      'locations.sql': "INSERT INTO locations (id) VALUES ('lin_bedroom');\n",
+      // Uppercase table + column identifiers; the bad value must still be caught.
+      'agents.sql':
+        "INSERT INTO AGENTS (ID, CURRENT_LOCATION_ID) VALUES ('eddy_lin', 'NOWHERE');\n",
+      'seed-order.txt': 'locations.sql\nagents.sql\n',
+    };
+    await withTempSeeds(seedFiles, async (tmp) => {
+      const result = validateSeeds(tmp, { seedOrderPath: join(tmp, 'seed-order.txt') });
+      const found = result.failures.some(f =>
+        f.check === 'fk-ref' && f.message.includes('NOWHERE'));
+      assert.ok(found,
+        'Uppercase identifiers should normalize so the FK rule still applies');
+    });
+  });
+
+  it('values: string literal case is PRESERVED (Rosie_Kim != rosie_kim)', async () => {
+    // The seeded agent id is 'rosie_kim'; a row references 'Rosie_Kim'.
+    // Postgres TEXT comparison is case-sensitive, so this should fail —
+    // identifier folding should not bleed into value comparison.
+    const seedFiles = {
+      'locations.sql': "INSERT INTO locations (id) VALUES ('lin_bedroom');\n",
+      'agents.sql':
+        "INSERT INTO agents (id, current_location_id) VALUES ('rosie_kim', 'lin_bedroom');\n",
+      // shops.owner_id -> agents.id, referencing a differently-cased value
+      'shops.sql':
+        "INSERT INTO shops (id, owner_id) VALUES ('shop_1', 'Rosie_Kim');\n",
+      'seed-order.txt': 'locations.sql\nagents.sql\nshops.sql\n',
+    };
+    await withTempSeeds(seedFiles, async (tmp) => {
+      const result = validateSeeds(tmp, { seedOrderPath: join(tmp, 'seed-order.txt') });
+      const found = result.failures.some(f =>
+        f.check === 'fk-ref' && f.message.includes('Rosie_Kim'));
+      assert.ok(found,
+        'FK value comparison must be case-sensitive: Rosie_Kim must not match seeded rosie_kim');
+    });
+  });
+
+  it('keywords: lowercase SQL keywords are still parsed (regression guard)', async () => {
+    const seedFiles = {
+      'locations.sql': "insert into locations (id) values ('lin_bedroom');\n",
+      'agents.sql':
+        "insert into agents (id, current_location_id) values ('eddy_lin', 'NOWHERE');\n",
+      'seed-order.txt': 'locations.sql\nagents.sql\n',
+    };
+    await withTempSeeds(seedFiles, async (tmp) => {
+      const result = validateSeeds(tmp, { seedOrderPath: join(tmp, 'seed-order.txt') });
+      const found = result.failures.some(f =>
+        f.check === 'fk-ref' && f.message.includes('NOWHERE'));
+      assert.ok(found,
+        'Lowercase insert/values keywords must still be parsed so the FK check runs');
+    });
+  });
+
+  // ── skip-vs-fail distinction ───────────────────────────────────────
+
+  it('skips a rule whose target table.column is never seeded', async () => {
+    // economy_transactions.from_agent_id -> agents.id exists in migrations,
+    // but if agents is not seeded at all there is nothing to check against,
+    // so the rule is skipped rather than failed.
+    const seedFiles = {
+      'economy_transactions.sql':
+        "INSERT INTO economy_transactions (id, from_agent_id) VALUES ('tx_1', 'ghost_agent');\n",
+      'seed-order.txt': 'economy_transactions.sql\n',
+    };
+    await withTempSeeds(seedFiles, async (tmp) => {
+      const result = validateSeeds(tmp, { seedOrderPath: join(tmp, 'seed-order.txt') });
+      const fkFailures = result.failures.filter(f => f.check === 'fk-ref');
+      assert.deepStrictEqual(fkFailures, [],
+        'A rule whose target is seeded nowhere should be skipped quietly');
+    });
+  });
+
+  it('fails when the target is seeded only in a later file', async () => {
+    // agents is seeded, but only after the file that references it. Tracking
+    // which values exist anywhere should not relax the order-sensitive check;
+    // a reference loaded too late should still fail.
+    const seedFiles = {
+      'locations.sql': "INSERT INTO locations (id) VALUES ('lin_bedroom');\n",
+      'shops.sql':
+        "INSERT INTO shops (id, owner_id) VALUES ('shop_1', 'eddy_lin');\n",
+      'agents.sql':
+        "INSERT INTO agents (id, current_location_id) VALUES ('eddy_lin', 'lin_bedroom');\n",
+      // shops loads BEFORE agents -> eddy_lin not yet available when shop_1 refs it
+      'seed-order.txt': 'locations.sql\nshops.sql\nagents.sql\n',
+    };
+    await withTempSeeds(seedFiles, async (tmp) => {
+      const result = validateSeeds(tmp, { seedOrderPath: join(tmp, 'seed-order.txt') });
+      const found = result.failures.some(f =>
+        f.check === 'fk-ref' && f.message.includes('eddy_lin'));
+      assert.ok(found,
+        'A reference to a value seeded only in a later file should still fail');
     });
   });
 


### PR DESCRIPTION
## Summary

Follow-up to #70 for #32.

This replaces the manual seed FK rule list with migration-derived FK rules, while preserving the existing order-aware validation behavior from the seed validator.

## Changes

- Derive FK checks from `world-api/migrations/*.sql`
- Preserve order-aware validation so references must be loaded by the current or earlier seed file
- Track FK targets by `table.column`
- Normalize unquoted SQL identifiers while preserving string value case
- Enforce schema-derived FK nullability
- Remove the misleading `async` signature from `validateSeeds`
- Update `CONTRIBUTING.md` to reflect that FK checks now derive from migrations

## Validation

- `node scripts/validate-seeds.mjs`
- `node --test scripts/validate-seeds.test.mjs` — 27/27 passing
- `git diff --check`

Docker bootstrap smoke was not rerun because this PR does not change seed data, migrations, or bootstrap behavior.